### PR TITLE
configurable NA and validation

### DIFF
--- a/tcases-lib/src/main/java/org/cornutum/tcases/AbstractVarDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/AbstractVarDef.java
@@ -10,12 +10,13 @@ package org.cornutum.tcases;
 import org.cornutum.tcases.conditions.AllOf;
 import org.cornutum.tcases.conditions.ICondition;
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
 
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 /**
  * Base class for {@link IVarDef} implementations.
@@ -103,7 +104,7 @@ public abstract class AbstractVarDef extends Conditional implements IVarDef
    */
   public void setName( String name)
     {
-    assertIdentifier( name);
+    getInputDefValidator().assertVarDefName( name);
     name_ = name;
     pathName_ = null;
     }
@@ -150,7 +151,7 @@ public abstract class AbstractVarDef extends Conditional implements IVarDef
    */
   public void setType( String type)
     {
-    assertIdentifier( type);
+    getInputDefValidator().assertVarDefType( type);
     type_ = type;
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/FunctionInputDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/FunctionInputDef.java
@@ -8,9 +8,11 @@
 package org.cornutum.tcases;
 
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 import org.apache.commons.lang3.StringUtils;
+import org.cornutum.tcases.validation.DefUtils;
 
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -47,7 +49,7 @@ public class FunctionInputDef extends Annotated
     {
     if( name != null)
       {
-      assertIdentifier( name);
+      getInputDefValidator().assertFunctionName( name);
       }
     name_ = name;
     }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/FunctionTestDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/FunctionTestDef.java
@@ -8,13 +8,14 @@
 package org.cornutum.tcases;
 
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
 
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 /**
  * Defines test cases for a specific function.
@@ -43,7 +44,7 @@ public class FunctionTestDef extends Annotated
    */
   public void setName( String name)
     {
-    assertIdentifier( name);
+    getInputDefValidator().assertFunctionName( name);
     name_ = name;
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
@@ -1,0 +1,28 @@
+package org.cornutum.tcases;
+
+import org.cornutum.tcases.validation.DefinitionsValidator;
+
+/**
+ * Global constants, can be parametrized.
+ */
+public abstract class Globals
+  {
+
+  private static DefinitionsValidator validator;
+
+
+  public static DefinitionsValidator getInputDefValidator()
+    {
+    if (validator == null)
+      {
+      validator = new DefinitionsValidator();
+      }
+    return validator;
+    }
+
+  public static void setValidator(DefinitionsValidator validator)
+    {
+    Globals.validator = validator;
+    }
+
+  }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
@@ -9,6 +9,8 @@ public abstract class Globals
   {
 
   private static DefinitionsValidator validator;
+  private static String notApplicableName;
+  private static VarValueDef notApplicableVarValue;
 
 
   public static DefinitionsValidator getInputDefValidator()
@@ -25,4 +27,34 @@ public abstract class Globals
     Globals.validator = validator;
     }
 
+  public static void setNotApplicableName(String notApplicableName)
+    {
+    Globals.notApplicableName = notApplicableName;
+    }
+
+  public static String getNotApplicableName()
+    {
+    if (notApplicableName == null)
+      {
+      notApplicableName = "NA";
+      }
+    return notApplicableName;
+    }
+
+  /**
+   * Returns true if the given value is the standard "not applicable" value.
+   */
+  public static boolean isNA( VarValueDef value)
+    {
+    return getNotApplicableName().equals(value.getName());
+    }
+
+  public static VarValueDef getNotApplicableVarValue()
+    {
+    if (notApplicableVarValue == null)
+      {
+        notApplicableVarValue = new VarValueDef(getNotApplicableName());
+      }
+      return notApplicableVarValue;
+    }
   }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/Globals.java
@@ -1,5 +1,6 @@
 package org.cornutum.tcases;
 
+import org.cornutum.tcases.util.XmlWriterFactory;
 import org.cornutum.tcases.validation.DefinitionsValidator;
 
 /**
@@ -11,7 +12,21 @@ public abstract class Globals
   private static DefinitionsValidator validator;
   private static String notApplicableName;
   private static VarValueDef notApplicableVarValue;
+  private static XmlWriterFactory xmlWriterFactory;
 
+  public static XmlWriterFactory getXmlWriterFactory()
+    {
+    if (xmlWriterFactory == null)
+      {
+      xmlWriterFactory = new XmlWriterFactory();
+      }
+    return xmlWriterFactory;
+    }
+
+  public static void setXmlWriterFactory(XmlWriterFactory xmlWriterFactory)
+    {
+    Globals.xmlWriterFactory = xmlWriterFactory;
+    }
 
   public static DefinitionsValidator getInputDefValidator()
     {

--- a/tcases-lib/src/main/java/org/cornutum/tcases/SystemInputDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/SystemInputDef.java
@@ -8,11 +8,12 @@
 package org.cornutum.tcases;
 
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 /**
  * Defines the input space for all functions of a system.
@@ -41,7 +42,7 @@ public class SystemInputDef extends Annotated
    */
   public void setName( String name)
     {
-    assertIdentifier( name);
+    getInputDefValidator().assertSystemName( name);
     name_ = name;
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/SystemTestDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/SystemTestDef.java
@@ -8,13 +8,14 @@
 package org.cornutum.tcases;
 
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
 
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Iterator;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 /**
  * Defines the test cases for all functions of a system.
@@ -43,7 +44,7 @@ public class SystemTestDef extends Annotated
    */
   public void setName( String name)
     {
-    assertIdentifier( name);
+    getInputDefValidator().assertSystemName( name);
     name_ = name;
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/Tcases.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/Tcases.java
@@ -142,7 +142,7 @@ public class Tcases
         String value = binding.getValue();
 
         // Add value annotations...
-        if( !value.equals( VarValueDef.NA.getName()))
+        if( !value.equals( Globals.getNotApplicableName()))
           {
           VarValueDef valueDef = varDef.getValue( value);
           binding.addAnnotations( valueDef);

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarBinding.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarBinding.java
@@ -8,7 +8,7 @@
 package org.cornutum.tcases;
 
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -69,7 +69,7 @@ public class VarBinding extends Annotated implements Comparable<VarBinding>
    */
   public void setVar( String varName)
     {
-    assertPath( varName);
+    getInputDefValidator().assertVarBindingName( varName);
     var_ = varName;
     }
 
@@ -86,7 +86,7 @@ public class VarBinding extends Annotated implements Comparable<VarBinding>
    */
   public void setValue( String valueName)
     {
-    assertIdentifier( valueName);
+    getInputDefValidator().assertVarBindingValue( valueName);
     value_ = valueName;
     }
 
@@ -103,7 +103,7 @@ public class VarBinding extends Annotated implements Comparable<VarBinding>
    */
   public void setType( String type)
     {
-    assertIdentifier( type);
+    getInputDefValidator().assertVarBindingType( type);
     varType_ = type;
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarBinding.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarBinding.java
@@ -136,7 +136,7 @@ public class VarBinding extends Annotated implements Comparable<VarBinding>
    */
   public boolean isValueNA()
     {
-    return VarValueDef.NA.getName().equals( getValue());
+    return Globals.getNotApplicableName().equals( getValue());
     }
 
   /**

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarBindingDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarBindingDef.java
@@ -99,7 +99,7 @@ public class VarBindingDef
    */
   public boolean isNA()
     {
-    return VarValueDef.isNA( valueDef_);
+    return Globals.isNA( valueDef_);
     }
 
   @SuppressWarnings("deprecation")

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarDef.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.cornutum.tcases.Globals.isNA;
+
 /**
  * Defines an individual input variable.
  *
@@ -160,7 +162,7 @@ public class VarDef extends AbstractVarDef
     {
     return
       getValue( value.getName()) != null
-      || (VarValueDef.isNA( value) && isOptional());
+      || (isNA( value) && isOptional());
     }
 
   /**

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarSet.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarSet.java
@@ -10,6 +10,7 @@ package org.cornutum.tcases;
 import org.apache.commons.lang3.StringUtils;
 
 import org.cornutum.tcases.conditions.ICondition;
+import org.cornutum.tcases.validation.DefUtils;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarValueDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarValueDef.java
@@ -221,20 +221,6 @@ public class VarValueDef extends Conditional
       .toString();
     }
 
-  /**
-   * Returns true if the given value is the standard {@link #NA "not applicable"} value.
-   */
-  public static boolean isNA( VarValueDef value)
-    {
-    return value == NA;
-    }
-
-  /**
-   * The standard "not applicable" value. This value is valid for any variable that is
-   * "optional", i.e. that (has an ancestor that) defines a condition.
-   */
-  public static final VarValueDef NA = new VarValueDef( "NA");
-
   private String name_;
   private Type type_;
   private PropertySet properties_;

--- a/tcases-lib/src/main/java/org/cornutum/tcases/VarValueDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/VarValueDef.java
@@ -9,13 +9,14 @@ package org.cornutum.tcases;
 
 import org.cornutum.tcases.conditions.ICondition;
 import org.cornutum.tcases.util.ToString;
-import static org.cornutum.tcases.DefUtils.*;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 /**
  * Defines the properties of a value for an {@link IVarDef input variable}.
@@ -92,7 +93,7 @@ public class VarValueDef extends Conditional
    */
   public void setName( String name)
     {
-    assertIdentifier( name);
+    getInputDefValidator().assertValueName( name);
     name_ = name;
     }
 
@@ -161,7 +162,7 @@ public class VarValueDef extends Conditional
     {
     if( properties != null)
       {
-      assertPropertyIdentifiers( properties);
+      getInputDefValidator().assertPropertyIdentifiers( properties);
       getProperties().addAll( properties);
       }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/TestCaseDef.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/TestCaseDef.java
@@ -232,7 +232,7 @@ public class TestCaseDef implements Comparable<TestCaseDef>
       }
 
     // Adding "not applicable" binding?
-    else if( value != VarValueDef.NA)
+    else if( Globals.isNA(value))
       {
       // No, is this variable applicable to the current test case?
       if( !var.getEffectiveCondition().compatible( properties_))
@@ -341,7 +341,7 @@ public class TestCaseDef implements Comparable<TestCaseDef>
    */
   public boolean isNA( VarDef var)
     {
-    return VarValueDef.isNA( getBinding( var));
+    return Globals.isNA( getBinding( var));
     }
 
   /**
@@ -375,7 +375,7 @@ public class TestCaseDef implements Comparable<TestCaseDef>
         {
         VarDef var = vars.next();
         VarValueDef value = getBinding( var);
-        if( !VarValueDef.isNA( value))
+        if( !Globals.isNA( value))
           {
           conditions.add( var.getEffectiveCondition());
           conditions.add( Conditional.acquireCondition( value));

--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/TupleGenerator.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/TupleGenerator.java
@@ -587,7 +587,7 @@ public class TupleGenerator implements ITestCaseGenerator, Cloneable<TupleGenera
       VarDef var = naVars.next();
       if( var.isOptional())
         {
-        na.add( new Tuple( new VarBindingDef( var, VarValueDef.NA)));
+        na.add( new Tuple( new VarBindingDef( var, Globals.getNotApplicableVarValue())));
         }
       }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/VarNamePattern.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/VarNamePattern.java
@@ -10,6 +10,7 @@ package org.cornutum.tcases.generator;
 import org.cornutum.tcases.*;
 
 import org.apache.commons.lang3.StringUtils;
+import org.cornutum.tcases.validation.DefUtils;
 
 import java.util.Arrays;
 import java.util.Iterator;

--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocReader.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocReader.java
@@ -9,7 +9,8 @@ package org.cornutum.tcases.generator.io;
 
 import org.cornutum.tcases.VarBinding;
 import org.cornutum.tcases.generator.*;
-import static org.cornutum.tcases.DefUtils.*;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 import static org.cornutum.tcases.generator.io.GeneratorSetDoc.*;
 import static org.cornutum.tcases.generator.io.TupleGeneratorDoc.*;
 
@@ -73,7 +74,7 @@ public class GeneratorSetDocReader extends DefaultHandler implements IGeneratorS
 
       try
         {
-        assertIdentifier( id);
+        getInputDefValidator().assertAttributeValue( attributeName, id);
         }
       catch( Exception e)
         {
@@ -259,7 +260,7 @@ public class GeneratorSetDocReader extends DefaultHandler implements IGeneratorS
         {
         try
           {
-          assertIdentifier( functionName);
+          getInputDefValidator().assertFunctionName( functionName);
           }
         catch( Exception e)
           {

--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocWriter.java
@@ -7,6 +7,7 @@
 
 package org.cornutum.tcases.generator.io;
 
+import org.cornutum.tcases.Globals;
 import org.cornutum.tcases.VarBinding;
 import org.cornutum.tcases.generator.*;
 import org.cornutum.tcases.util.XmlWriter;
@@ -39,7 +40,7 @@ public class GeneratorSetDocWriter implements Closeable
    */
   public GeneratorSetDocWriter( OutputStream stream)
     {
-    this( new XmlWriter( stream));
+    this(Globals.getXmlWriterFactory().forStream(stream));
     }
   
   /**
@@ -47,7 +48,7 @@ public class GeneratorSetDocWriter implements Closeable
    */
   public GeneratorSetDocWriter( Writer writer)
     {
-    this( new XmlWriter( writer));
+    this( Globals.getXmlWriterFactory().forWriter( writer));
     }
   
   /**

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemInputDocReader.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemInputDocReader.java
@@ -10,7 +10,7 @@ package org.cornutum.tcases.io;
 import org.cornutum.tcases.*;
 import org.cornutum.tcases.conditions.*;
 
-import static org.cornutum.tcases.DefUtils.*;
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -97,7 +97,7 @@ public class SystemInputDocReader extends DefaultHandler implements ISystemInput
         {
         try
           {
-          assertIdentifier( id);
+          getInputDefValidator().assertAttributeValue( attributeName, id);
           }
         catch( Exception e)
           {
@@ -221,7 +221,7 @@ public class SystemInputDocReader extends DefaultHandler implements ISystemInput
 
         try
           {
-          assertPropertyIdentifiers( propertySet);
+          getInputDefValidator().assertPropertyIdentifiers( propertySet);
           }
         catch( Exception e)
           {

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocReader.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocReader.java
@@ -8,7 +8,8 @@
 package org.cornutum.tcases.io;
 
 import org.cornutum.tcases.*;
-import static org.cornutum.tcases.DefUtils.*;
+
+import static org.cornutum.tcases.Globals.getInputDefValidator;
 import static org.cornutum.tcases.io.SystemTestDoc.*;
 
 import javax.xml.parsers.SAXParser;
@@ -140,7 +141,7 @@ public class SystemTestDocReader extends DefaultHandler implements ISystemTestSo
         {
         try
           {
-          assertIdentifier( id);
+          getInputDefValidator().assertAttributeValue( attributeName, id);
           }
         catch( Exception e)
           {
@@ -178,7 +179,7 @@ public class SystemTestDocReader extends DefaultHandler implements ISystemTestSo
         {
         try
           {
-          assertPath( id);
+          getInputDefValidator().assertAttributeValueAsPath( attributeName, id);
           }
         catch( Exception e)
           {

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocWriter.java
@@ -204,7 +204,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
    */
   protected void setWriter( Writer writer)
     {
-    setXmlWriter( new XmlWriter( writer));
+    setXmlWriter( Globals.getXmlWriterFactory().forWriter( writer));
     }
 
   /**

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestHtmlWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestHtmlWriter.java
@@ -399,7 +399,7 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
    */
   protected void setWriter( Writer writer)
     {
-    setXmlWriter( new XmlWriter( writer));
+    setXmlWriter( Globals.getXmlWriterFactory().forWriter( writer));
     }
 
   /**

--- a/tcases-lib/src/main/java/org/cornutum/tcases/util/XmlWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/util/XmlWriter.java
@@ -19,7 +19,7 @@ public class XmlWriter extends IndentedWriter
   /**
    * Creates a new XmlWriter object.
    */
-  public XmlWriter( OutputStream output)
+  protected XmlWriter( OutputStream output)
     {
     super( output);
     }
@@ -27,7 +27,7 @@ public class XmlWriter extends IndentedWriter
   /**
    * Creates a new XmlWriter object.
    */
-  public XmlWriter( Writer writer)
+  protected XmlWriter( Writer writer)
     {
     super( writer);
     }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/util/XmlWriterFactory.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/util/XmlWriterFactory.java
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////////////
+// 
+//                    Copyright 2012, Cornutum Project
+//                             www.cornutum.org
+//
+//////////////////////////////////////////////////////////////////////////////
+
+package org.cornutum.tcases.util;
+
+import java.io.OutputStream;
+import java.io.Writer;
+  
+/**
+ * Supports creation of an XML document stream.
+ *
+ */
+public class XmlWriterFactory
+  {
+  /**
+   * Creates a new XmlWriter object.
+   */
+  public XmlWriter forStream( OutputStream output)
+    {
+    return new XmlWriter( output);
+    }
+
+  /**
+   * Creates a new XmlWriter object.
+   */
+  public XmlWriter forWriter( Writer writer)
+    {
+    return new XmlWriter( writer);
+    }
+  }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/validation/DefUtils.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/validation/DefUtils.java
@@ -5,7 +5,7 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-package org.cornutum.tcases;
+package org.cornutum.tcases.validation;
 
 import java.util.Collection;
 import java.util.regex.Pattern;
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  * Defines utility methods for constructing test definitions.
  *
  */
-public abstract class DefUtils
+public class DefUtils
   {
   /**
    * Returns true if the given string is a valid identifier.
@@ -39,7 +39,7 @@ public abstract class DefUtils
   /**
    * Throws an exception if the given string is not a valid identifier.
    */
-  public static void assertIdentifier( String id) throws IllegalArgumentException
+  static void assertIdentifier( String id) throws IllegalArgumentException
     {
     if( !isIdentifier( id))
       {
@@ -53,7 +53,7 @@ public abstract class DefUtils
   /**
    * Throws an exception if the given string is not a valid identifier path name.
    */
-  public static void assertPath( String pathName) throws IllegalArgumentException
+  static void assertPath( String pathName) throws IllegalArgumentException
     {
     String ids[] = toPath( pathName);
     for( int i = 0; i < ids.length; i++)
@@ -65,7 +65,7 @@ public abstract class DefUtils
   /**
    * Throws an exception if any member of the given set of properties is not a valid identifier.
    */
-  public static void assertPropertyIdentifiers( Collection<String> properties) throws IllegalArgumentException
+  static void assertPropertyIdentifiers( Collection<String> properties) throws IllegalArgumentException
     {
     if( properties != null)
       {

--- a/tcases-lib/src/main/java/org/cornutum/tcases/validation/DefinitionsValidator.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/validation/DefinitionsValidator.java
@@ -1,0 +1,66 @@
+package org.cornutum.tcases.validation;
+
+import java.util.Collection;
+
+/**
+ * Defines default validations for given model elements.
+ * Can be replaced in Globals with custom validators for different rules.
+ */
+public class DefinitionsValidator
+  {
+
+  public void assertSystemName( String name)
+    {
+    new DefUtils().assertIdentifier( name);
+    }
+
+  public void assertFunctionName( String name)
+    {
+    new DefUtils().assertIdentifier( name);
+    }
+
+  public void assertVarBindingType( String type)
+    {
+    new DefUtils().assertIdentifier( type);
+    }
+
+  public void assertVarBindingName( String varName)
+    {
+    new DefUtils().assertPath( varName);
+    }
+
+  public void assertVarBindingValue( String valueName)
+    {
+    new DefUtils().assertIdentifier( valueName);
+    }
+
+  public void assertValueName( String name)
+    {
+    new DefUtils().assertIdentifier( name);
+    }
+
+  public void assertPropertyIdentifiers( Collection<String> properties)
+    {
+    new DefUtils().assertPropertyIdentifiers( properties);
+    }
+
+  public void assertVarDefName( String name)
+    {
+    new DefUtils().assertIdentifier( name);
+    }
+
+  public void assertVarDefType( String type)
+    {
+    new DefUtils().assertIdentifier( type);
+    }
+
+  public void assertAttributeValue(String attributeName, String id)
+    {
+    new DefUtils().assertIdentifier( id);
+    }
+
+  public void assertAttributeValueAsPath(String attributeName, String id)
+    {
+    new DefUtils().assertPath( id);
+    }
+  }

--- a/tcases-lib/src/test/java/org/cornutum/tcases/FunctionInputDefBuilder.java
+++ b/tcases-lib/src/test/java/org/cornutum/tcases/FunctionInputDefBuilder.java
@@ -8,6 +8,8 @@
 
 package org.cornutum.tcases;
 
+import org.cornutum.tcases.validation.DefUtils;
+
 import java.util.Arrays;
 
 /**

--- a/tcases-lib/src/test/java/org/cornutum/tcases/VarSetBuilder.java
+++ b/tcases-lib/src/test/java/org/cornutum/tcases/VarSetBuilder.java
@@ -8,6 +8,8 @@
 
 package org.cornutum.tcases;
 
+import org.cornutum.tcases.validation.DefUtils;
+
 import java.util.Arrays;
 
 /**


### PR DESCRIPTION
The PR makes it possible for library users of TCases to override the "NA" value for "not applicable, and the rules for validation of string values that are part of an inputDef or testDef.

I can imagine several further patches to make Tcases more configurable as a library. The key idea is that customizing users are responsible themselves if anything breaks, but they can make many customizations without having to fork tcases, and thus also patch bugs easily instead of depending on you to make a new release.

I am not particularly proud of using the Globals class like that, but short of adding a DI framework like Guice or Dagger, I am not sure how the codebase could be made configurable with justifiable effort.