### PR TITLE
Refactor and fix minor xml creation regression

### DIFF
--- a/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/generator/io/GeneratorSetDocWriter.java
@@ -126,13 +126,13 @@ public class GeneratorSetDocWriter implements Closeable
         {
         Arrays.stream( combiner.getIncluded())
           .sorted()
-          .forEach( included -> writeIncluded( included));
+          .forEach( this::writeIncluded);
         
         Arrays.stream( combiner.getExcluded())
           .sorted()
-          .forEach( excluded -> writeExcluded( excluded));
+          .forEach( this::writeExcluded);
 
-        toStream( combiner.getOnceTuples()).forEach( tuple -> writeOnceTuple( tuple));
+        toStream( combiner.getOnceTuples()).forEach( this::writeOnceTuple);
         })
       .write();
     }
@@ -144,10 +144,7 @@ public class GeneratorSetDocWriter implements Closeable
     {
     writer_
       .element( ONCE_TAG)
-      .content( () ->
-        {
-        toStream( tuple.getVarBindings()).forEach( varBinding -> writeVarBinding( varBinding));
-        })
+      .content( () -> toStream( tuple.getVarBindings()).forEach( this::writeVarBinding))
       .write();
     }
 

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemInputDocWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemInputDocWriter.java
@@ -63,7 +63,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
       .content( () ->
         {
         writeAnnotations( systemInput);
-        toStream( systemInput.getFunctionInputDefs()).forEach( function -> writeFunction( function));
+        toStream( systemInput.getFunctionInputDefs()).forEach( this::writeFunction);
         })
       .write();
     }
@@ -99,10 +99,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
     xmlWriter_
       .element( INPUT_TAG)
       .attribute( TYPE_ATR, varType)
-      .content( () ->
-        {
-        varDefs.forEach( varDef -> writeVarDef( varDef));
-        })
+      .content( () -> varDefs.forEach( this::writeVarDef))
       .write();
     }
 
@@ -138,11 +135,11 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
         conditionWriter.writeWhenElement();
         if( varTag.equals( VAR_TAG))
           {
-          values.forEach( value -> writeValue( value));
+          values.forEach( this::writeValue);
           }
         else
           {
-          members.forEach( member -> writeVarDef( member));
+          members.forEach( this::writeVarDef);
           }
         })
       .write();
@@ -183,7 +180,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
           .attribute( NAME_ATR, annotation)
           .attribute( VALUE_ATR, annotated.getAnnotation( annotation))
           .write();
-        }); 
+        });
     }
 
   private Optional<String> propertyList( Stream<String> properties)
@@ -198,7 +195,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
   /**
    * Flushes the writer.
    */
-  public void flush() throws IOException
+  public void flush()
     {
     getXmlWriter().flush();
     }
@@ -253,7 +250,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
         {
         xmlWriter_
           .element( WHEN_TAG)
-          .content( () -> { condition_.accept( this); })
+          .content( () -> condition_.accept( this))
           .write();
         }
       }
@@ -272,9 +269,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
         .element( ALLOF_TAG)
         .attributeIf( PROPERTY_ATR, propertiesOf( condition, ContainsAll.class))
         .content( () ->
-          {
-          visit( withoutPropertiesOf( condition, ContainsAll.class));
-          })
+                visit( withoutPropertiesOf( condition, ContainsAll.class)))
         .write();
       }
   
@@ -284,9 +279,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
         .element( ANYOF_TAG)
         .attributeIf( PROPERTY_ATR, propertiesOf( condition, ContainsAny.class))
         .content( () ->
-          {
-          visit( withoutPropertiesOf( condition, ContainsAny.class));
-          })
+                visit( withoutPropertiesOf( condition, ContainsAny.class)))
         .write();
       }
   
@@ -317,9 +310,7 @@ public class SystemInputDocWriter extends AbstractSystemInputWriter
         .element( NOT_TAG)
         .attributeIf( PROPERTY_ATR, propertiesOf( condition, ContainsAny.class))
         .content( () ->
-          {
-          visit( withoutPropertiesOf( condition, ContainsAny.class));
-          })
+                visit( withoutPropertiesOf( condition, ContainsAny.class)))
         .write();
       }
   

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestDocWriter.java
@@ -60,7 +60,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
       .content( () ->
         {
         writeAnnotations( systemTest);
-        toStream( systemTest.getFunctionTestDefs()).forEach( function -> writeFunction( function));
+        toStream( systemTest.getFunctionTestDefs()).forEach( this::writeFunction);
         })
       .write();
     }
@@ -78,7 +78,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
         writeAnnotations( function);
         toStream( function.getTestCases())
           .sorted()
-          .forEach( testCase -> writeTestCase( testCase));
+          .forEach( this::writeTestCase);
         })
       .write();
     }
@@ -112,7 +112,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
         {
         toStream( testCase.getVarBindings( type))
           .sorted()
-          .forEach( binding -> writeBinding( binding));
+          .forEach( this::writeBinding);
         })
       .write();
     }
@@ -128,10 +128,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
       .attributeIf( binding.isValueNA(), NA_ATR, "true")
       .attributeIf( !binding.isValueNA(), VALUE_ATR, String.valueOf( binding.getValue()))
       .attributeIf( !binding.isValueValid(), FAILURE_ATR, "true")
-      .content( () ->
-        {
-        writeAnnotations( binding);
-        })
+      .content( () -> writeAnnotations( binding))
       .write();
     }
 
@@ -154,7 +151,7 @@ public class SystemTestDocWriter extends AbstractSystemTestWriter
   /**
    * Flushes the writer.
    */
-  public void flush() throws IOException
+  public void flush()
     {
     getXmlWriter().flush();
     }

--- a/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestHtmlWriter.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/io/SystemTestHtmlWriter.java
@@ -116,7 +116,7 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
           .element( "BODY")
           .content( () ->
             {
-            toStream( systemTest.getFunctionTestDefs()).forEach( function -> writeFunction( function));
+            toStream( systemTest.getFunctionTestDefs()).forEach( this::writeFunction);
             if( defaultStyle)
               {
               writeDefaultScript();
@@ -183,13 +183,7 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
     Iterator<VarBinding> varBindings =
       IteratorUtils.filteredIterator
         ( testCase.getVarBindings( type),
-          new Predicate<VarBinding>()
-             {
-             public boolean evaluate( VarBinding binding)
-                {
-                return !binding.isValueNA();
-                }
-            });
+          binding -> !binding.isValueNA());
 
     if( varBindings.hasNext())
       {
@@ -232,10 +226,7 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
 
           xmlWriter_
             .element( "TD")
-            .content( () ->
-              {
-              writeVarSets( varSetLevel + 1, varBindings);
-              })
+            .content( () -> writeVarSets( varSetLevel + 1, varBindings))
             .write();
           })
         .write();
@@ -254,11 +245,11 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
         {
         String varSet = "";
         String varSetNext = "";
-        for( PeekingIterator<VarBinding> peekBindings = new PeekingIterator<VarBinding>( varBindings);
+        for( PeekingIterator<VarBinding> peekBindings = new PeekingIterator<>( varBindings);
              peekBindings.hasNext();
              varSet = varSetNext)
           {
-          List<VarBinding> varSetBindings = new ArrayList<VarBinding>();
+          List<VarBinding> varSetBindings = new ArrayList<>();
           for( varSetNext = "";
 
                peekBindings.hasNext()
@@ -363,7 +354,7 @@ public class SystemTestHtmlWriter extends AbstractSystemTestWriter
   /**
    * Flushes the writer.
    */
-  public void flush() throws IOException
+  public void flush()
     {
     getXmlWriter().flush();
     }


### PR DESCRIPTION
Hi, 
refactorings in first commit are as suggested by IDE (IntelliJ), feel free to reject without long justification. I assume the tool you manipulate code with does not offer suggestions to improve code to take benefit of new java8 features, so I believe in those places you did not intentionally use a more verbose style, but I might be wrong about that.

The regression is about rendering xml tags not self-closing because there is a non-null contentWriter, but the contentWriter does not print any String.

The same could happen for any other usage of the xml writer, though goind back to the change commit 6ac71f1709fe911c , I believe this is the only previous conditional usage of writeEmptyElementEnd(), so maybe the only regression. 

For the future this is of course a vulnerability due to the new Structure being based on side-effects instead of pure functions, so any caller adding a contentWriter has the responsibility to not add a contentWriter that will not write. Restructuring the code to avoid this is possible, but touches many places in the code, so I did not dare work on that.