### PR TITLE
ApiTestCommand: Add option to generate separate test files for each API resource path

### DIFF
--- a/tcases-cli/src/test/java/org/cornutum/tcases/openapi/ApiTestCommandByPathTest.java
+++ b/tcases-cli/src/test/java/org/cornutum/tcases/openapi/ApiTestCommandByPathTest.java
@@ -1,0 +1,342 @@
+//////////////////////////////////////////////////////////////////////////////
+// 
+//                    Copyright 2021, Cornutum Project
+//                             www.cornutum.org
+//
+//////////////////////////////////////////////////////////////////////////////
+
+package org.cornutum.tcases.openapi;
+
+import org.cornutum.tcases.openapi.ApiTestCommand.Options;
+import org.cornutum.tcases.openapi.testwriter.TestWriterTest;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+
+/**
+ * Runs tests for {@link ApiTestCommand}.
+ */
+public class ApiTestCommandByPathTest extends TestWriterTest
+  {
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 0. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Simple </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> Absolute </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> One </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> No </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_0() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    File outFile = new File( getResourceDir( "byPath_0"), "ActualTestClass");
+    
+    String[] args =
+      {
+        "-S",
+        "-P", "/post",
+        "-n", "MyTest",
+        "-p", "org.cornutum.examples",
+        "-f", outFile.getPath(),
+        "-r", "20210517"
+      };
+    
+    // When...
+    runWithStdIO( new Options( args), apiFile, null);
+        
+    // Then...
+    verifyTestsByPath( "byPath_0", outFile.getParentFile());
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 1. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Fqn </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> (not applicable) </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> Default </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> Yes </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test 
+  public void byPath_1() throws Exception
+    {
+    // Given...
+    File apiFile = new File( getResourceDir( "byPath_1"), "OpenApiTest.json");
+    
+    String[] args =
+      {
+        "-n", "org.cornutum.examples.AllPaths",
+        "-S",
+        apiFile.getPath()
+      };
+
+    // When...
+    ApiTestCommand.run( new Options( args));
+    
+    // Then...
+    verifyTestsByPath( "byPath_1", apiFile.getParentFile());
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 2. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Fqn </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> Relative </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> Many </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> No </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_2() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    File outDir = getResourceDir( "byPath_2");
+    
+    String[] args =
+      {
+        "-n", "org.cornutum.examples.SomePaths",
+        "-f", "SomePathsTestCases.java",
+        "-o", outDir.getPath(),
+        "-P", "/posts/{userId}/{[attributes]},/users",
+        "-r", "20210517",
+        "-S"
+      };
+
+    // When...
+    runWithStdIO( new Options( args), apiFile, null);
+    
+    // Then...
+    verifyTestsByPath( "byPath_2", outDir);
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 3. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Default </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> (not applicable) </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> One </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> Yes </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_3() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    File outDir = getResourceDir( "byPath_3");
+
+    String[] args =
+      {
+        "-p", "org.cornutum.examples",
+        "-o", outDir.getPath(),
+        "-P", "/posts/{userId}/{[attributes]}",
+        "-S",
+        apiFile.getPath()
+      };
+
+    // When...
+    ApiTestCommand.run( new Options( args));
+    
+    // Then...
+    verifyTestsByPath( "byPath_3", outDir);
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 4. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Simple </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> (not applicable) </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> Default </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> No </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_4() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    File outDir = getResourceDir( "byPath_4");
+    
+    String[] args =
+      {
+        "-S",
+        "-n", "My Simple Test",
+        "-o", outDir.getPath(),
+        "-p", "org.cornutum.examples",
+        "-r", "20210517"
+      };
+    
+    // When...
+    runWithStdIO( new Options( args), apiFile, null);
+        
+    // Then...
+    verifyTestsByPath( "byPath_4", outDir);
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 5. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Default </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> Absolute </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> Many </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> Yes </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_5() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    File outFile = new File( getResourceDir( "byPath_5"), "Results");
+
+    String[] args =
+      {
+        "-p", "org.cornutum.examples",
+        "-f", outFile.getPath(),
+        "-P", "/posts,/post,/users",
+        "-S",
+        apiFile.getPath()
+      };
+
+    // When...
+    ApiTestCommand.run( new Options( args));
+    
+    // Then...
+    verifyTestsByPath( "byPath_5", outFile.getParentFile());
+    }
+
+  /**
+   * Tests {@link ApiTestCommand#run run()} using the following inputs.
+   * <P>
+   * <TABLE border="1" cellpadding="8">
+   * <TR align="left"><TH colspan=2> 6. run (Success) </TH></TR>
+   * <TR align="left"><TH> Input Choice </TH> <TH> Value </TH></TR>
+   * <TR><TD> ByPath </TD> <TD> Yes </TD> </TR>
+   * <TR><TD> Test-Name </TD> <TD> Default </TD> </TR>
+   * <TR><TD> Output-File.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Output-File.Path </TD> <TD> (not applicable) </TD> </TR>
+   * <TR><TD> Output-Dir.Defined </TD> <TD> No </TD> </TR>
+   * <TR><TD> Paths </TD> <TD> Many </TD> </TR>
+   * <TR><TD> Api-Spec.Defined </TD> <TD> No </TD> </TR>
+   * </TABLE>
+   * </P>
+   */
+  @Test
+  public void byPath_6() throws Exception
+    {
+    // Given...
+    File apiFile = stdApiSpec( "OpenApiTest");
+    
+    String[] args =
+      {
+        "-S",
+        "-p", "org.cornutum.examples",
+        "-r", "20210517"
+      };
+    
+    // When...
+    StringBuffer stdOut = new StringBuffer();
+    runWithStdIO( new Options( args), apiFile, stdOut);
+        
+    // Then...
+    String testFileResults = stdOut.toString();
+    verifyTest( "byPath_6", testFileResults);
+    }
+
+  /**
+   * Run Tcases with the given options, using the given standard input/output.
+   * If <CODE>stdIn</CODE> is non-null, redirect standard input to read from the given file.
+   * If <CODE>stdOut</CODE> is non-null, redirect standard output to write to the given buffer.
+   */
+  private void runWithStdIO( Options options, File stdIn, StringBuffer stdOut) throws Exception
+    {
+    InputStream prevIn = System.in;
+    PrintStream prevOut = System.out;
+
+    InputStream newIn = null;
+    PrintStream newOut = null;
+    ByteArrayOutputStream newOutBytes = null;
+    
+    try
+      {
+      if( stdIn != null)
+        {
+        System.setIn( (newIn = new FileInputStream( stdIn)));
+        }
+
+      if( stdOut != null)
+        {
+        stdOut.delete( 0, stdOut.length());
+        System.setOut( (newOut = new PrintStream( (newOutBytes = new ByteArrayOutputStream()))));
+        }
+
+      ApiTestCommand.run( options);
+      }
+    finally
+      {
+      IOUtils.closeQuietly( newIn, null);
+      IOUtils.closeQuietly( newOut, null);
+
+      System.setIn( prevIn);
+      System.setOut( prevOut);
+
+      if( newOutBytes != null)
+        {
+        stdOut.append( new String( newOutBytes.toByteArray(), Charset.forName( "UTF-8")));
+        }
+      }
+    }
+  }

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_0-Expected/MyTest_PostTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_0-Expected/MyTest_PostTest.java
@@ -1,0 +1,700 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MyTest_PostTest {
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_VIP() {
+        given()
+            .queryParam( "post?[post-references]", "1,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_2() {
+        given()
+            .queryParam( "post?[post-references]", "2,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_NotObject() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes", "-699.6")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "{vz0c([_F@'\"4E%yI=i)s.g=LFn%SSq.4M?.g1-W >AuVibu1b4au-fF<6rX)7MIH:y(/?E+6{os~)X2veU]-%v!0p/pC !G%wgsK)'HA(>Wv&C\"|in~2p?-0IC4RyPhoL$Q\\|1$S)\\>_")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+            .queryParam( "user attributes[ucvn]", "true")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_Null() {
+        given()
+            .queryParam( "post?", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_NotObject() {
+        given()
+            .queryParam( "post?", "638")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_NotArray() {
+        given()
+            .queryParam( "post?[post-references]", "-224")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_1() {
+        given()
+            .queryParam( "post?[post-references]", "0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_3() {
+        given()
+            .queryParam( "post?[post-references]", "0,1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", ",2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "post?[post-references]", ",\")j\\}|,?+hI|y,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "-8421636,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsUnique_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "post?[knd]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_Yes() {
+        given()
+            .queryParam( "Post Marks", "{X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_3() {
+        given()
+            .queryParam( "Post Marks", "<Y> {X} #Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Z() {
+        given()
+            .queryParam( "Post Marks", "#Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsUnique_Is_No() {
+        given()
+            .queryParam( "Post Marks", "{X} {X} <Y>")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_No() {
+        given()
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_NotArray() {
+        given()
+            .queryParam( "Post Marks", "403.3")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_0() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_4() {
+        given()
+            .queryParam( "Post Marks", "<Y> #Z {X} {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=4
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "Post Marks", "b}(U6Xfe`>]?lpy,CJQd6kIkW_U+H3/98854vP.[y}R5y!2%3%_Y/'1\\(~|,)qXKnH")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_Yes() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_Gt_0() {
+        given()
+            .queryParam( "postId", "803445276551147189.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "(?)")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_MeYou() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Me+You")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_No() {
+        given()
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_Null() {
+        given()
+            .queryParam( "postId", "")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_NotNumber() {
+        given()
+            .queryParam( "postId", ")eC^@^\\A")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=Not number
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_M1() {
+        given()
+            .queryParam( "postId", "-1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyDefined_Is_No() {
+        given()
+            .queryParam( "postId", "856313282084416394.1")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyMediaType_Is_Other() {
+        given()
+            .queryParam( "postId", "515349763337368011.7")
+            .contentType( "text/xml")
+            .request().body( "-859.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_Null() {
+        given()
+            .queryParam( "postId", "507487423726193757.6")
+            .contentType( "application/x-www-form-urlencoded")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_NotObject() {
+        given()
+            .queryParam( "postId", "915631707044085407.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "number", "5.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .queryParam( "postId", "338691171953762326.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_Null() {
+        given()
+            .queryParam( "postId", "478596007308032957.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .queryParam( "postId", "420095667913229974.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerDefined_Is_No() {
+        given()
+            .queryParam( "postId", "94273501035354036.6")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerType_Is_Null() {
+        given()
+            .queryParam( "postId", "597422243307448674.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_Other() {
+        given()
+            .queryParam( "postId", "616970863794345540.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", ":zpa1JvdLE;q5~*.^/XIYik~:\"sH!Tr2kV)X*(]mZ]8' ")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "postId", "377378332398273490.1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+            .formParam( "lezmvljb", "true")
+            .formParam( "cdrlletpkaho", "562")
+            .formParam( "xrlwx", "S,_9,W}W")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostTest.java
@@ -1,0 +1,701 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_PostTest {
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_VIP() {
+        given()
+            .queryParam( "post?[post-references]", "1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_2() {
+        given()
+            .queryParam( "post?[post-references]", "2,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_NotObject() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "-163.3")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "*76s/1*r")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+            .queryParam( "user attributes[wfgawhzebqxw]", "-993.3")
+            .queryParam( "user attributes[bt]", "-646")
+            .queryParam( "user attributes[d]", "429")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_Null() {
+        given()
+            .queryParam( "post?", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_NotObject() {
+        given()
+            .queryParam( "post?", "-689.9")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_NotArray() {
+        given()
+            .queryParam( "post?[post-references]", "true")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_1() {
+        given()
+            .queryParam( "post?[post-references]", "0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_3() {
+        given()
+            .queryParam( "post?[post-references]", "0,1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", ",1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "post?[post-references]", ",,NU,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "518413185,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsUnique_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "post?[pfuxkykifiozux]", "g\"YtKR,&")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_Yes() {
+        given()
+            .queryParam( "Post Marks", "{X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_3() {
+        given()
+            .queryParam( "Post Marks", "<Y> {X} #Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Z() {
+        given()
+            .queryParam( "Post Marks", "#Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsUnique_Is_No() {
+        given()
+            .queryParam( "Post Marks", "{X} {X} {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_No() {
+        given()
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_NotArray() {
+        given()
+            .queryParam( "Post Marks", "+")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_0() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_4() {
+        given()
+            .queryParam( "Post Marks", "<Y> <Y> <Y> {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=4
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "Post Marks", "#/lL\"%`\\M,7/RPK2]eZ/b\"LtW=MB6,(")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_Yes() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_Gt_0() {
+        given()
+            .queryParam( "postId", "884128300094585099.3")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "(?)")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_MeYou() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Me+You")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_No() {
+        given()
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_Null() {
+        given()
+            .queryParam( "postId", "")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_NotNumber() {
+        given()
+            .queryParam( "postId", "%")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=Not number
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_M1() {
+        given()
+            .queryParam( "postId", "-1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyDefined_Is_No() {
+        given()
+            .queryParam( "postId", "579110988210992054.5")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyMediaType_Is_Other() {
+        given()
+            .queryParam( "postId", "100055597218570470.8")
+            .contentType( "application/xml")
+            .request().body( ">jg-FQI")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_Null() {
+        given()
+            .queryParam( "postId", "545768800747318227.7")
+            .contentType( "application/x-www-form-urlencoded")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_NotObject() {
+        given()
+            .queryParam( "postId", "787781271506673512.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "string", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .queryParam( "postId", "887390451195556957.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_Null() {
+        given()
+            .queryParam( "postId", "218911377319422868.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .queryParam( "postId", "847512139010470218.2")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "eytx,7ea{")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerDefined_Is_No() {
+        given()
+            .queryParam( "postId", "711003745143914146.9")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerType_Is_Null() {
+        given()
+            .queryParam( "postId", "167771822150204639.4")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_Other() {
+        given()
+            .queryParam( "postId", "886308504886987482.6")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "i&")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "postId", "920816794015899048.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+            .formParam( "dxobuuyffc", "true")
+            .formParam( "wssfr", "true")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostUseridApprovedTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostUseridApprovedTest.java
@@ -1,0 +1,160 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_PostUseridApprovedTest {
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1000() {
+        given()
+            .pathParam( "approved", ".1")
+            .pathParam( "userId", ".1000")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_No() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_Null() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".Ti0q{}")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".-1")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1001() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".1001")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=1001
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedDefined_Is_No() {
+        given()
+            .pathParam( "approved", "")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_Null() {
+        given()
+            .pathParam( "approved", ".")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".true")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedValue_Is_Other() {
+        given()
+            .pathParam( "approved", ".-39383625")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsAttributesTest.java
@@ -1,0 +1,208 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_PostsAttributesTest {
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=A Day In Hell;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedValue_Is_False() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=597033979")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_WhatMeWorry() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=What? Me, worry?;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", "")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";attributes")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "attributes", ";attributes=-441")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";likes=1035843385")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=;likes=127128009")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "attributes", ";approved=\"+DZYOH4;likes=222686173")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";approved=false")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=true")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=-1")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=;likes=279878075")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_Other() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=~+:.-g:o)lz~^hL-;. o1\\Vc64a#.Sm!*Y`|qrPD^$*wXi2.a22Qkgt|f8T;#g33QP&F3Sq{<43[l#SP:C>1C~NW?G\\a _%Jkm?u2\"l\"H7*]q:f9@re;likes=859073676")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=776704486;wuf=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsTest.java
@@ -1,0 +1,1097 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_PostsTest {
+
+    @Test
+    public void getPosts_IdsDefined_Is_Yes() {
+        given()
+            .queryParam( "ids", "0")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_4() {
+        given()
+            .queryParam( "ids", "100|93|41|58")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsDefined_Is_No() {
+        given()
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_NotArray() {
+        given()
+            .queryParam( "ids", "27")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_0() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_5() {
+        given()
+            .queryParam( "ids", "0|85|16|15|7")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=5
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "ids", "%lB,,iZ7s")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_M1() {
+        given()
+            .queryParam( "ids", "-1")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_101() {
+        given()
+            .queryParam( "ids", "101")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=101
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsUnique_Is_No() {
+        given()
+            .queryParam( "ids", "0|82|16|16")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_Yes() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_2345() {
+        given()
+            .header( "X-Post-Types", "2345,7700")
+            .header( "X-User-Id", "305257074")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_7700() {
+        given()
+            .header( "X-Post-Types", "7700,1001")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_No() {
+        given()
+            .header( "X-User-Id", "633125734")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "908798277")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_NotArray() {
+        given()
+            .header( "X-Post-Types", "true")
+            .header( "X-User-Id", "45784771")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_1() {
+        given()
+            .header( "X-Post-Types", "1001")
+            .header( "X-User-Id", "454534268")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_3() {
+        given()
+            .header( "X-Post-Types", "1001,2345,7700")
+            .header( "X-User-Id", "199793883")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_Null() {
+        given()
+            .header( "X-Post-Types", ",1001")
+            .header( "X-User-Id", "530075126")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "true,2345")
+            .header( "X-User-Id", "685227360")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_Other() {
+        given()
+            .header( "X-Post-Types", "220811161,1001")
+            .header( "X-User-Id", "807325043")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsUnique_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,1001")
+            .header( "X-User-Id", "212382841")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdDefined_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "EC]h<,G\"3+*")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdValue_Is_M1() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+            .header( "X-User-Id", "-1")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_Yes() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"^@z.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedValue_Is_False() {
+        given()
+            .cookie( "approved", "false")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_32() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"R)Z=aRk9 O X699I4brEZc)}_H]~YGFQ[u7+[Y{1jvMl\\\\?fP`ZaHE\\\\}tmHpOpb:$\",\"email\":\"7l`.TTd.+7p.TsH.ix;@eGpUw8WI.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_No() {
+        given()
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_Null() {
+        given()
+            .cookie( "approved", "")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_NotBoolean() {
+        given()
+            .cookie( "approved", "864.8")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/xml")
+            .request().body( "[\"7&)E$\\\\1\",\"b;7\",\"lJ}rpY>H\"]")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "null")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_NotObject() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "-394")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":{\"ojuslephkogs\":\"O+\\\"q[j\"}}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"fR.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"rROlqhu.sK`/Fa9@P.bYh.ZiC.Ppf.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"email\":\"'@e.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":null,\"email\":\"^@j.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":{\"xtgcbcxgfoi\":true,\"rqnrarsvehz\":\"t\",\"kxodoxjnhruqlc\":-55},\"email\":\"f@y.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"5Tr|w`=C8;V~x]FkwIVg-us5r0!]cKW/BU<tb$Q2<fbMlh$?7iFs\\\"Nx$~*VJQWa{@\",\"email\":\"j@9.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"z@6.com\",\"i\":true,\"zhbygokxf\":true,\"hbwvniykc\":true}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "country", "f")
+            .cookie( "region", "U")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|@g.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_16() {
+        given()
+            .cookie( "country", "3?yf*R>MA(|%pz}@")
+            .cookie( "region", "x8U}z3%?N$)|r!FQ")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\")@Pxh_%0+3b#tkKys=2JtkX\\\"mXVZ]bCFkngr[zxur1da$%Pz\\\"a>Orl/(Y}a_q-M5\",\"email\":\"8rM.?GYI.3Xq$@8g.sOO.YAD.VG3.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_No() {
+        given()
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"'@2.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|@4.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_NotObject() {
+        given()
+            .cookie( "postId", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"O@T.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryDefined_Is_No() {
+        given()
+            .cookie( "region", ")")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"{@0.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryType_Is_Null() {
+        given()
+            .cookie( "country", "")
+            .cookie( "region", "F")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@M.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_17() {
+        given()
+            .cookie( "country", "j'AJKsh61`bvz&f^7")
+            .cookie( "region", ".")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@F.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionDefined_Is_No() {
+        given()
+            .cookie( "country", "<")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"k@b.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionType_Is_Null() {
+        given()
+            .cookie( "country", "%")
+            .cookie( "region", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@m.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionValueLength_Is_17() {
+        given()
+            .cookie( "country", "m")
+            .cookie( "region", "F~v>f|K%35t[U3nn}")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"P@v.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "W")
+            .cookie( "region", "0")
+            .cookie( "xtrylgzujvaskrsm", "-+%")
+            .cookie( "osgrs", "-625.2")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@Q.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyDefined_Is_No() {
+        given()
+            .cookie( "country", "@")
+            .cookie( "region", "o")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "country", "q")
+            .cookie( "region", "q")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "string", " (&O;=")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_Null() {
+        given()
+            .cookie( "country", "t")
+            .cookie( "region", ".")
+            .contentType( "text/plain")
+            .request().body( "null")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_NotObject() {
+        given()
+            .cookie( "country", ")")
+            .cookie( "region", "H")
+            .contentType( "text/plain")
+            .request().body( "-463")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "country", "B")
+            .cookie( "region", "'")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "country", "U")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "country", "V")
+            .cookie( "region", "q")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"F7.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "country", "Y")
+            .cookie( "region", "D")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"Ku.#5c._&*.!`~.fPV@j.0c.bm.I4.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "country", "_")
+            .cookie( "region", "<")
+            .contentType( "text/plain")
+            .request().body( "{\"email\":\"F@Y.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "country", "J")
+            .cookie( "region", "&")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":null,\"email\":\"+@J.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "country", "#")
+            .cookie( "region", "$")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"JPt TLg/#+P9F03USC(F12J)k+BE<&oGTJh<RrmNe6-yTg=G<?qA\\\\MHn+L:c\\\"B7~'\",\"email\":\"q@2.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "O")
+            .cookie( "region", "6")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"g@I.org\",\"qlrcnlkwzq\":\"[oIUO\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "postId", "A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_2() {
+        given()
+            .cookie( "postId", "B|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_C() {
+        given()
+            .cookie( "postId", "C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_No() {
+        given()
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_NotArray() {
+        given()
+            .cookie( "postId", "568.0")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_0() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_3() {
+        given()
+            .cookie( "postId", "A|B|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsType_Is_Null() {
+        given()
+            .cookie( "postId", "|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_Other() {
+        given()
+            .cookie( "postId", "jLId'31*^UjExCZerfw#(S_b#m[(L&~c@x{Xp7Btyr+R+'p[jrH_o$X`LnQgI'mW?MxXRGcS[=P2R2jAx5z4OLaEDo=8cde$AvZR#F#0>Z[cld8Em_%vE!{(9$+z!(Ghc.{J[m^1HdT/7PKLdR0v:@srfapHf(c/l2s&<{QFg8oMlvF<0@dbS:.5ef?WOZ+>MHIUD-{?yH$5-DM3*T>hR%ct'(7EzCR]8|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsUnique_Is_No() {
+        given()
+            .cookie( "postId", "A|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsUseridAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_PostsUseridAttributesTest.java
@@ -1,0 +1,211 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_PostsUseridAttributesTest {
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=0")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_Gt_0() {
+        given()
+            .pathParam( "[attributes]", "approved=false")
+            .pathParam( "userId", "361643225")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "[attributes]", "likes=548990533")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "$$jsW^f_,,jxOXXRb")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "-1")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "357334495")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "[attributes]", "-772.4")
+            .pathParam( "userId", "471978604")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertyCount_Is_Lt_1() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "944897639")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Property-Count=< 1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=")
+            .pathParam( "userId", "515833097")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "[attributes]", "approved=cyhdwbn,rUyOPpmo,hvkexe,337.6")
+            .pathParam( "userId", "1066915565")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=")
+            .pathParam( "userId", "143212479")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=true")
+            .pathParam( "userId", "728445295")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=-1")
+            .pathParam( "userId", "171293516")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,blsssh=,osdpcfswhlbninro=-981.1,ublzqiqwnlq=true")
+            .pathParam( "userId", "814600097")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_UsersTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1-Expected/AllPaths_UsersTest.java
@@ -1,0 +1,29 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class AllPaths_UsersTest {
+
+    @Test
+    public void getUsers() {
+        given()
+        .when()
+            .request( "GET", "/users")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1/OpenApiTest.json
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_1/OpenApiTest.json
@@ -1,0 +1,547 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "OpenAPI Request Test Cases",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/posts": {
+            "trace": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [ "A", "B", "C"]
+                            },
+                            "minItems": 1,
+                            "maxItems": 2,
+                            "uniqueItems": true
+                        },
+                        "example": [ "A", "C"]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "options": {
+                "parameters": [
+                    {
+                        "name": "X-Post-Types",
+                        "required": true,
+                        "in": "header",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "enum": [ 1001, 2345, 7700 ]
+                            },
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "uniqueItems": true
+                        },
+                        "examples": {
+                            "1": { "value": [ 1001, 2345 ]},
+                            "2": { "value": [ 7700, 2345 ]},
+                            "3": { "value": [ 1001, 7700 ]}
+                        }
+                    },
+                    {
+                        "name": "X-User-Id",
+                        "required": true,
+                        "in": "header",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "example": 255
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "post": {
+                "parameters": [
+                    {
+                        "name": "approved",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "maxLength": 32
+                                    },
+                                    "text": {
+                                        "type": "string",
+                                        "minLength": 0,
+                                        "maxLength": 64
+                                    }
+                                },
+                                "required": [ "email", "text" ],
+                                "additionalProperties": false
+                            },
+                            "examples": {
+                                "1": { "value": {"email": "howdy@hello.com", "text": ""}},
+                                "2": { "value": {"email": "hi@hello.com", "text": "informal"}},
+                                "3": { "value": {"email": "hola@hello.com", "text": "jaunty"}}
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "get": {
+                "parameters": [
+                    {
+                        "name": "ids",
+                        "required": true,
+                        "in": "query",
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100
+                            },
+                            "minItems": 1,
+                            "maxItems": 4,
+                            "uniqueItems": true,
+                            "example": [ 50 ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+
+            "put": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "form",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "country": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 16
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 16
+                                }
+                            },
+                            "required": [ "country", "region" ],
+                            "additionalProperties": false
+                        },
+                        "example": {"country": "USA", "region": "West"}
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "text/plain": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "maxLength": 32
+                                    },
+                                    "text": {
+                                        "type": "string",
+                                        "minLength": 0,
+                                        "maxLength": 64
+                                    }
+                                },
+                                "required": [ "email", "text" ],
+                                "additionalProperties": false,
+                                "example": {"email": "hello@hello.com", "text": "standard"}
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/posts/{userId}/{[attributes]}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "required": true,
+                        "in": "path",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "examples": {
+                            "1": { "value": 1 },
+                            "2": { "value": 22 },
+                            "3": { "value": 3333 }
+                        }
+                    },
+                    {
+                        "name": "[attributes]",
+                        "required": true,
+                        "in": "path",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "approved": {
+                                    "type": "boolean"
+                                },
+                                "likes": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "example": 12345
+                                }
+                            },
+                            "minProperties": 1,
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+
+        "/posts/{attributes}": {
+            "trace": {
+                "parameters": [
+                    {
+                        "name": "attributes",
+                        "required": true,
+                        "in": "path",
+                        "style": "matrix",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "approved": {
+                                    "type": "boolean"
+                                },
+                                "likes": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "subject": {
+                                    "type": "string",
+                                    "enum": [ "A Day In Hell", "What? Me, worry?" ]
+                                }
+                            },
+                            "required": [ "approved", "likes" ],
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/post": {
+            "put": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0
+                        },
+                        "examples": {
+                            "1": { "value": 1.23 },
+                            "2": { "value": -456.78 },
+                            "3": { "value": 9.01 }
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "approved": {
+                                        "type": "boolean"
+                                    },
+                                    "reviewer": {
+                                        "type": "string",
+                                        "enum": [ "Larry Moe", "(?)", "Me+You"]
+                                    }
+                                },
+                                "required": [ "approved", "reviewer" ],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+
+            "head": {
+                "parameters": [
+                    {
+                        "name": "user attributes",
+                        "required": true,
+                        "in": "query",
+                        "style": "deepObject",
+                        "explode": false,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user type": {
+                                    "type": "string",
+                                    "enum": [ "Typical User", "VIP!" ]
+                                }
+                            },
+                            "required": [ "user type" ],
+                            "additionalProperties": false
+                        }
+                    },
+                    {
+                        "name": "post?",
+                        "required": true,
+                        "in": "query",
+                        "style": "deepObject",
+                        "explode": false,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "post references": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer",
+                                        "enum": [ 0, 1, 2 ]
+                                    },
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "uniqueItems": true
+                                }
+                            },
+                            "required": [ "post references" ],
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "patch": {
+                "parameters": [
+                    {
+                        "name": "Post Marks",
+                        "required": true,
+                        "in": "query",
+                        "style": "spaceDelimited",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [ "{X}", "<Y>", "#Z" ]
+                            },
+                            "minItems": 1,
+                            "maxItems": 3
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/post/{userId}/{approved}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "required": true,
+                        "in": "path",
+                        "style": "label",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1000
+                        },
+                        "example": 999
+                    },
+                    {
+                        "name": "approved",
+                        "required": true,
+                        "in": "path",
+                        "style": "label",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "enum": [ 0, 1 ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+
+        "/users": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "requestBodies": {
+            "standard": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "responses": {
+            "success": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "failure": {
+                "description": "Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_2-Expected/SomePaths_PostsUseridAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_2-Expected/SomePaths_PostsUseridAttributesTest.java
@@ -1,0 +1,211 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class SomePaths_PostsUseridAttributesTest {
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=0")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_Gt_0() {
+        given()
+            .pathParam( "[attributes]", "approved=false")
+            .pathParam( "userId", "681271971")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "[attributes]", "likes=706422332")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "-1")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "619183171")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "[attributes]", "%(ER,e{PU,Yw|Re")
+            .pathParam( "userId", "1030958588")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertyCount_Is_Lt_1() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "1037528634")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Property-Count=< 1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=")
+            .pathParam( "userId", "965022493")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "[attributes]", "approved=iodyhmr,true,osoeucjjcbyfuju,-215")
+            .pathParam( "userId", "909733668")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=")
+            .pathParam( "userId", "551606192")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=w")
+            .pathParam( "userId", "338978897")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=-1")
+            .pathParam( "userId", "1010487514")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,cfpdruj=v6=k\"yI")
+            .pathParam( "userId", "726508116")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_2-Expected/SomePaths_UsersTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_2-Expected/SomePaths_UsersTest.java
@@ -1,0 +1,29 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class SomePaths_UsersTest {
+
+    @Test
+    public void getUsers() {
+        given()
+        .when()
+            .request( "GET", "/users")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_3-Expected/OpenAPIRequestTestCases_PostsUseridAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_3-Expected/OpenAPIRequestTestCases_PostsUseridAttributesTest.java
@@ -1,0 +1,211 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostsUseridAttributesTest {
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=0")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_Gt_0() {
+        given()
+            .pathParam( "[attributes]", "approved=false")
+            .pathParam( "userId", "361643225")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "[attributes]", "likes=548990533")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "$$jsW^f_,,jxOXXRb")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "-1")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "357334495")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "[attributes]", "-772.4")
+            .pathParam( "userId", "471978604")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertyCount_Is_Lt_1() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "944897639")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Property-Count=< 1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=")
+            .pathParam( "userId", "515833097")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "[attributes]", "approved=cyhdwbn,rUyOPpmo,hvkexe,337.6")
+            .pathParam( "userId", "1066915565")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=")
+            .pathParam( "userId", "143212479")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=true")
+            .pathParam( "userId", "728445295")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=-1")
+            .pathParam( "userId", "171293516")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,blsssh=,osdpcfswhlbninro=-981.1,ublzqiqwnlq=true")
+            .pathParam( "userId", "814600097")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostTest.java
@@ -1,0 +1,700 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_PostTest {
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_VIP() {
+        given()
+            .queryParam( "post?[post-references]", "1,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_2() {
+        given()
+            .queryParam( "post?[post-references]", "2,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_NotObject() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes", "-699.6")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "{vz0c([_F@'\"4E%yI=i)s.g=LFn%SSq.4M?.g1-W >AuVibu1b4au-fF<6rX)7MIH:y(/?E+6{os~)X2veU]-%v!0p/pC !G%wgsK)'HA(>Wv&C\"|in~2p?-0IC4RyPhoL$Q\\|1$S)\\>_")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+            .queryParam( "user attributes[ucvn]", "true")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_Null() {
+        given()
+            .queryParam( "post?", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_NotObject() {
+        given()
+            .queryParam( "post?", "638")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_NotArray() {
+        given()
+            .queryParam( "post?[post-references]", "-224")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_1() {
+        given()
+            .queryParam( "post?[post-references]", "0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_3() {
+        given()
+            .queryParam( "post?[post-references]", "0,1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", ",2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "post?[post-references]", ",\")j\\}|,?+hI|y,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "-8421636,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsUnique_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "post?[knd]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_Yes() {
+        given()
+            .queryParam( "Post Marks", "{X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_3() {
+        given()
+            .queryParam( "Post Marks", "<Y> {X} #Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Z() {
+        given()
+            .queryParam( "Post Marks", "#Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsUnique_Is_No() {
+        given()
+            .queryParam( "Post Marks", "{X} {X} <Y>")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_No() {
+        given()
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_NotArray() {
+        given()
+            .queryParam( "Post Marks", "403.3")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_0() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_4() {
+        given()
+            .queryParam( "Post Marks", "<Y> #Z {X} {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=4
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "Post Marks", "b}(U6Xfe`>]?lpy,CJQd6kIkW_U+H3/98854vP.[y}R5y!2%3%_Y/'1\\(~|,)qXKnH")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_Yes() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_Gt_0() {
+        given()
+            .queryParam( "postId", "803445276551147189.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "(?)")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_MeYou() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Me+You")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_No() {
+        given()
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_Null() {
+        given()
+            .queryParam( "postId", "")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_NotNumber() {
+        given()
+            .queryParam( "postId", ")eC^@^\\A")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=Not number
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_M1() {
+        given()
+            .queryParam( "postId", "-1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyDefined_Is_No() {
+        given()
+            .queryParam( "postId", "856313282084416394.1")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyMediaType_Is_Other() {
+        given()
+            .queryParam( "postId", "515349763337368011.7")
+            .contentType( "text/xml")
+            .request().body( "-859.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_Null() {
+        given()
+            .queryParam( "postId", "507487423726193757.6")
+            .contentType( "application/x-www-form-urlencoded")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_NotObject() {
+        given()
+            .queryParam( "postId", "915631707044085407.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "number", "5.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .queryParam( "postId", "338691171953762326.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_Null() {
+        given()
+            .queryParam( "postId", "478596007308032957.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .queryParam( "postId", "420095667913229974.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerDefined_Is_No() {
+        given()
+            .queryParam( "postId", "94273501035354036.6")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerType_Is_Null() {
+        given()
+            .queryParam( "postId", "597422243307448674.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_Other() {
+        given()
+            .queryParam( "postId", "616970863794345540.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", ":zpa1JvdLE;q5~*.^/XIYik~:\"sH!Tr2kV)X*(]mZ]8' ")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "postId", "377378332398273490.1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+            .formParam( "lezmvljb", "true")
+            .formParam( "cdrlletpkaho", "562")
+            .formParam( "xrlwx", "S,_9,W}W")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostUseridApprovedTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostUseridApprovedTest.java
@@ -1,0 +1,160 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_PostUseridApprovedTest {
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1000() {
+        given()
+            .pathParam( "approved", ".1")
+            .pathParam( "userId", ".1000")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_No() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_Null() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".248.1")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".-1")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1001() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".1001")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=1001
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedDefined_Is_No() {
+        given()
+            .pathParam( "approved", "")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_Null() {
+        given()
+            .pathParam( "approved", ".")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedValue_Is_Other() {
+        given()
+            .pathParam( "approved", ".925787165")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsAttributesTest.java
@@ -1,0 +1,208 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_PostsAttributesTest {
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=A Day In Hell;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedValue_Is_False() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=514682280")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_WhatMeWorry() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=What? Me, worry?;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", "")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";attributes")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "attributes", ";attributes=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";likes=640659892")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=;likes=835347369")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "attributes", ";approved=ltgjsaarufjsntz,39.8,nmjvnsa,-388.5,asyxuquvohcwtz,true;likes=6787962")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";approved=false")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=-663.1")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=-1")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=;likes=187325925")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_Other() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=(/fQ+iXAv6[oToMT*B60a#-lu2U[ 6M~/]G8te^x?ev/ZGRSe'o_7G'lT6n:2 TGq64S?G55LA}?\"nCf4bt)Jda:O-1JP/r\\#*;DZkLr}5v=:[OgEJkwNsAWd#w{=acXgFE}K+}U5Hk5KT'maYikYsS{R$VAC2mS{:D/I~Sd\"%HcE.3j|/& #e2Ak5-H52vY6QA-FsF|~nyK9bCaxM.}DpZ%9,j].;likes=831591488")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=803777274;i=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsTest.java
@@ -1,0 +1,1096 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_PostsTest {
+
+    @Test
+    public void getPosts_IdsDefined_Is_Yes() {
+        given()
+            .queryParam( "ids", "0")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_4() {
+        given()
+            .queryParam( "ids", "100|35|31|12")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsDefined_Is_No() {
+        given()
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_NotArray() {
+        given()
+            .queryParam( "ids", "-6")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_0() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_5() {
+        given()
+            .queryParam( "ids", "0|80|63|32|91")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=5
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_M1() {
+        given()
+            .queryParam( "ids", "-1")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_101() {
+        given()
+            .queryParam( "ids", "101")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=101
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsUnique_Is_No() {
+        given()
+            .queryParam( "ids", "0|33|92|92")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_Yes() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_2345() {
+        given()
+            .header( "X-Post-Types", "2345,7700")
+            .header( "X-User-Id", "46782787")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_7700() {
+        given()
+            .header( "X-Post-Types", "7700,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_No() {
+        given()
+            .header( "X-User-Id", "1002717876")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "295907700")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_NotArray() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "940566730")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_1() {
+        given()
+            .header( "X-Post-Types", "1001")
+            .header( "X-User-Id", "995957995")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_3() {
+        given()
+            .header( "X-Post-Types", "1001,2345,7700")
+            .header( "X-User-Id", "543574415")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_Null() {
+        given()
+            .header( "X-Post-Types", ",7700")
+            .header( "X-User-Id", "324488672")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "_0>6l,1001")
+            .header( "X-User-Id", "156012952")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_Other() {
+        given()
+            .header( "X-Post-Types", "260738342,1001")
+            .header( "X-User-Id", "330205658")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsUnique_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,1001")
+            .header( "X-User-Id", "287469117")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdDefined_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", ";UA")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdValue_Is_M1() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+            .header( "X-User-Id", "-1")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_Yes() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"m@W.com\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedValue_Is_False() {
+        given()
+            .cookie( "approved", "false")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_32() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"ezMe2&I.\\\"aMq>yn}=%E|qk,BL`=d\\\\',p6z*[3:hJZwGvOPrjzu61{$ek@KVCB]|8\",\"email\":\"2.6.=.&.?.K.I.s.!@7sq9.96wcX.edu\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_No() {
+        given()
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_Null() {
+        given()
+            .cookie( "approved", "")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_NotBoolean() {
+        given()
+            .cookie( "approved", "g<h[(2")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/xml")
+            .request().body( "{\"yqjvfkkbpw\":-423.0,\"lnyiywnpwriprxz\":-902}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "null")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_NotObject() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "709.7")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":37.6}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"Jm.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"QLv?Bb963Fs.YrQLFE;nR~eE@6w6O.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"email\":\"2@N.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":null,\"email\":\"+@A.com\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":true,\"email\":\"r@S.edu\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\",XM8YB6+me$jhjpa5B#QsXRRyK4s=zT)f_fpwYXqdu21?A] 5t8uZe7$5NG0Wed b\",\"email\":\"z@I.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"o@g.gov\",\"oychp\":-638.3,\"iimkfycd\":[],\"kuhhctjnrda\":805}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "country", "I")
+            .cookie( "region", "W")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"0@p.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_16() {
+        given()
+            .cookie( "country", ":IEt|~VjQA_R}TA(")
+            .cookie( "region", "#:iPPHOumVFtB^@r")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"JFQM3N>B1#lB/U{OHId-;1^nGH1l+ah#,#![^s\\\\brAMrXLB\\\\ u$[V><]\\\"dv*RKO;\",\"email\":\"GJ@W.kds.PHn.7DP.5GF.aNX.OZp.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_No() {
+        given()
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"R@L.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"B@N.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_NotObject() {
+        given()
+            .cookie( "postId", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@i.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryDefined_Is_No() {
+        given()
+            .cookie( "region", "h")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"*@3.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryType_Is_Null() {
+        given()
+            .cookie( "country", "")
+            .cookie( "region", "k")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"l@u.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_17() {
+        given()
+            .cookie( "country", "GF:-Al}%h'$N)k5Nn")
+            .cookie( "region", "#")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@O.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionDefined_Is_No() {
+        given()
+            .cookie( "country", "b")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"{@V.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionType_Is_Null() {
+        given()
+            .cookie( "country", "[")
+            .cookie( "region", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"v@S.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionValueLength_Is_17() {
+        given()
+            .cookie( "country", ".")
+            .cookie( "region", ")dzW[S-YC=k7?yx?K")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"U@z.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "%")
+            .cookie( "region", "T")
+            .cookie( "fvwfwnxkmrev", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"A@3.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyDefined_Is_No() {
+        given()
+            .cookie( "country", "c")
+            .cookie( "region", "t")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "country", "I")
+            .cookie( "region", "~")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "boolean", "true")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_Null() {
+        given()
+            .cookie( "country", "O")
+            .cookie( "region", "+")
+            .contentType( "text/plain")
+            .request().body( "null")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_NotObject() {
+        given()
+            .cookie( "country", "?")
+            .cookie( "region", "@")
+            .contentType( "text/plain")
+            .request().body( "193")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "country", "w")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "country", "[")
+            .cookie( "region", "?")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "country", "@")
+            .cookie( "region", "x")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"j6.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "country", "$")
+            .cookie( "region", "l")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|7Gr.Ptv.A'U@r.Cn3N.o79T.57vS.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "country", "D")
+            .cookie( "region", "s")
+            .contentType( "text/plain")
+            .request().body( "{\"email\":\"q@L.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "country", "s")
+            .cookie( "region", "n")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":null,\"email\":\"j@4.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "country", "Y")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"S:Y2'%=]f[\\\"jLb$%[]\\\\ae(_<-<MP\\\\f~(Qe)c#9}P`CkQ <[8liE&[lM(raFH&GF3.\",\"email\":\"=@3.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "h")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"t@d.gov\",\"mnxgkkxm\":-180}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "postId", "A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_2() {
+        given()
+            .cookie( "postId", "B|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_C() {
+        given()
+            .cookie( "postId", "C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_No() {
+        given()
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_NotArray() {
+        given()
+            .cookie( "postId", "true")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_0() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_3() {
+        given()
+            .cookie( "postId", "A|C|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsType_Is_Null() {
+        given()
+            .cookie( "postId", "|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_Other() {
+        given()
+            .cookie( "postId", "3=rI:rH7jvN+>LNx0M#eAmB3|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsUnique_Is_No() {
+        given()
+            .cookie( "postId", "A|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsUseridAttributesTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_PostsUseridAttributesTest.java
@@ -1,0 +1,211 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_PostsUseridAttributesTest {
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=0")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_Gt_0() {
+        given()
+            .pathParam( "[attributes]", "approved=false")
+            .pathParam( "userId", "681271971")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "[attributes]", "likes=706422332")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "-1")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "619183171")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "[attributes]", "%(ER,e{PU,Yw|Re")
+            .pathParam( "userId", "1030958588")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertyCount_Is_Lt_1() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "1037528634")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Property-Count=< 1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=")
+            .pathParam( "userId", "965022493")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "[attributes]", "approved=iodyhmr,true,osoeucjjcbyfuju,-215")
+            .pathParam( "userId", "909733668")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=")
+            .pathParam( "userId", "551606192")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=w")
+            .pathParam( "userId", "338978897")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=-1")
+            .pathParam( "userId", "1010487514")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,cfpdruj=v6=k\"yI")
+            .pathParam( "userId", "726508116")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_UsersTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_4-Expected/MySimpleTest_UsersTest.java
@@ -1,0 +1,29 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class MySimpleTest_UsersTest {
+
+    @Test
+    public void getUsers() {
+        given()
+        .when()
+            .request( "GET", "/users")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_PostTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_PostTest.java
@@ -1,0 +1,701 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class Results_PostTest {
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_VIP() {
+        given()
+            .queryParam( "post?[post-references]", "1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_2() {
+        given()
+            .queryParam( "post?[post-references]", "2,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_NotObject() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "-163.3")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "*76s/1*r")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+            .queryParam( "user attributes[wfgawhzebqxw]", "-993.3")
+            .queryParam( "user attributes[bt]", "-646")
+            .queryParam( "user attributes[d]", "429")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_Null() {
+        given()
+            .queryParam( "post?", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_NotObject() {
+        given()
+            .queryParam( "post?", "-689.9")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_NotArray() {
+        given()
+            .queryParam( "post?[post-references]", "true")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_1() {
+        given()
+            .queryParam( "post?[post-references]", "0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_3() {
+        given()
+            .queryParam( "post?[post-references]", "0,1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", ",1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "post?[post-references]", ",,NU,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "518413185,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsUnique_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "post?[pfuxkykifiozux]", "g\"YtKR,&")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_Yes() {
+        given()
+            .queryParam( "Post Marks", "{X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_3() {
+        given()
+            .queryParam( "Post Marks", "<Y> {X} #Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Z() {
+        given()
+            .queryParam( "Post Marks", "#Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsUnique_Is_No() {
+        given()
+            .queryParam( "Post Marks", "{X} {X} {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_No() {
+        given()
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_NotArray() {
+        given()
+            .queryParam( "Post Marks", "+")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_0() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_4() {
+        given()
+            .queryParam( "Post Marks", "<Y> <Y> <Y> {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=4
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "Post Marks", "#/lL\"%`\\M,7/RPK2]eZ/b\"LtW=MB6,(")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_Yes() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_Gt_0() {
+        given()
+            .queryParam( "postId", "884128300094585099.3")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "(?)")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_MeYou() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Me+You")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_No() {
+        given()
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_Null() {
+        given()
+            .queryParam( "postId", "")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_NotNumber() {
+        given()
+            .queryParam( "postId", "%")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=Not number
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_M1() {
+        given()
+            .queryParam( "postId", "-1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyDefined_Is_No() {
+        given()
+            .queryParam( "postId", "579110988210992054.5")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyMediaType_Is_Other() {
+        given()
+            .queryParam( "postId", "100055597218570470.8")
+            .contentType( "application/xml")
+            .request().body( ">jg-FQI")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_Null() {
+        given()
+            .queryParam( "postId", "545768800747318227.7")
+            .contentType( "application/x-www-form-urlencoded")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_NotObject() {
+        given()
+            .queryParam( "postId", "787781271506673512.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "string", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .queryParam( "postId", "887390451195556957.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_Null() {
+        given()
+            .queryParam( "postId", "218911377319422868.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .queryParam( "postId", "847512139010470218.2")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "eytx,7ea{")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerDefined_Is_No() {
+        given()
+            .queryParam( "postId", "711003745143914146.9")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerType_Is_Null() {
+        given()
+            .queryParam( "postId", "167771822150204639.4")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_Other() {
+        given()
+            .queryParam( "postId", "886308504886987482.6")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "i&")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "postId", "920816794015899048.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+            .formParam( "dxobuuyffc", "true")
+            .formParam( "wssfr", "true")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_PostsTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_PostsTest.java
@@ -1,0 +1,1097 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class Results_PostsTest {
+
+    @Test
+    public void getPosts_IdsDefined_Is_Yes() {
+        given()
+            .queryParam( "ids", "0")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_4() {
+        given()
+            .queryParam( "ids", "100|93|41|58")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsDefined_Is_No() {
+        given()
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_NotArray() {
+        given()
+            .queryParam( "ids", "27")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_0() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_5() {
+        given()
+            .queryParam( "ids", "0|85|16|15|7")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=5
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "ids", "%lB,,iZ7s")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_M1() {
+        given()
+            .queryParam( "ids", "-1")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_101() {
+        given()
+            .queryParam( "ids", "101")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=101
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsUnique_Is_No() {
+        given()
+            .queryParam( "ids", "0|82|16|16")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_Yes() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_2345() {
+        given()
+            .header( "X-Post-Types", "2345,7700")
+            .header( "X-User-Id", "305257074")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_7700() {
+        given()
+            .header( "X-Post-Types", "7700,1001")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_No() {
+        given()
+            .header( "X-User-Id", "633125734")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "908798277")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_NotArray() {
+        given()
+            .header( "X-Post-Types", "true")
+            .header( "X-User-Id", "45784771")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_1() {
+        given()
+            .header( "X-Post-Types", "1001")
+            .header( "X-User-Id", "454534268")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_3() {
+        given()
+            .header( "X-Post-Types", "1001,2345,7700")
+            .header( "X-User-Id", "199793883")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_Null() {
+        given()
+            .header( "X-Post-Types", ",1001")
+            .header( "X-User-Id", "530075126")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "true,2345")
+            .header( "X-User-Id", "685227360")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_Other() {
+        given()
+            .header( "X-Post-Types", "220811161,1001")
+            .header( "X-User-Id", "807325043")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsUnique_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,1001")
+            .header( "X-User-Id", "212382841")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdDefined_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "EC]h<,G\"3+*")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdValue_Is_M1() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+            .header( "X-User-Id", "-1")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_Yes() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"^@z.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedValue_Is_False() {
+        given()
+            .cookie( "approved", "false")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_32() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"R)Z=aRk9 O X699I4brEZc)}_H]~YGFQ[u7+[Y{1jvMl\\\\?fP`ZaHE\\\\}tmHpOpb:$\",\"email\":\"7l`.TTd.+7p.TsH.ix;@eGpUw8WI.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_No() {
+        given()
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_Null() {
+        given()
+            .cookie( "approved", "")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_NotBoolean() {
+        given()
+            .cookie( "approved", "864.8")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/xml")
+            .request().body( "[\"7&)E$\\\\1\",\"b;7\",\"lJ}rpY>H\"]")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "null")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_NotObject() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "-394")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":{\"ojuslephkogs\":\"O+\\\"q[j\"}}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"fR.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"rROlqhu.sK`/Fa9@P.bYh.ZiC.Ppf.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"email\":\"'@e.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":null,\"email\":\"^@j.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":{\"xtgcbcxgfoi\":true,\"rqnrarsvehz\":\"t\",\"kxodoxjnhruqlc\":-55},\"email\":\"f@y.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"5Tr|w`=C8;V~x]FkwIVg-us5r0!]cKW/BU<tb$Q2<fbMlh$?7iFs\\\"Nx$~*VJQWa{@\",\"email\":\"j@9.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"z@6.com\",\"i\":true,\"zhbygokxf\":true,\"hbwvniykc\":true}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "country", "f")
+            .cookie( "region", "U")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|@g.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_16() {
+        given()
+            .cookie( "country", "3?yf*R>MA(|%pz}@")
+            .cookie( "region", "x8U}z3%?N$)|r!FQ")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\")@Pxh_%0+3b#tkKys=2JtkX\\\"mXVZ]bCFkngr[zxur1da$%Pz\\\"a>Orl/(Y}a_q-M5\",\"email\":\"8rM.?GYI.3Xq$@8g.sOO.YAD.VG3.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_No() {
+        given()
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"'@2.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|@4.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_NotObject() {
+        given()
+            .cookie( "postId", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"O@T.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryDefined_Is_No() {
+        given()
+            .cookie( "region", ")")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"{@0.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryType_Is_Null() {
+        given()
+            .cookie( "country", "")
+            .cookie( "region", "F")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@M.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_17() {
+        given()
+            .cookie( "country", "j'AJKsh61`bvz&f^7")
+            .cookie( "region", ".")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@F.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionDefined_Is_No() {
+        given()
+            .cookie( "country", "<")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"k@b.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionType_Is_Null() {
+        given()
+            .cookie( "country", "%")
+            .cookie( "region", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@m.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionValueLength_Is_17() {
+        given()
+            .cookie( "country", "m")
+            .cookie( "region", "F~v>f|K%35t[U3nn}")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"P@v.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "W")
+            .cookie( "region", "0")
+            .cookie( "xtrylgzujvaskrsm", "-+%")
+            .cookie( "osgrs", "-625.2")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@Q.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyDefined_Is_No() {
+        given()
+            .cookie( "country", "@")
+            .cookie( "region", "o")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "country", "q")
+            .cookie( "region", "q")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "string", " (&O;=")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_Null() {
+        given()
+            .cookie( "country", "t")
+            .cookie( "region", ".")
+            .contentType( "text/plain")
+            .request().body( "null")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_NotObject() {
+        given()
+            .cookie( "country", ")")
+            .cookie( "region", "H")
+            .contentType( "text/plain")
+            .request().body( "-463")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "country", "B")
+            .cookie( "region", "'")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "country", "U")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "country", "V")
+            .cookie( "region", "q")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"F7.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "country", "Y")
+            .cookie( "region", "D")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"Ku.#5c._&*.!`~.fPV@j.0c.bm.I4.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "country", "_")
+            .cookie( "region", "<")
+            .contentType( "text/plain")
+            .request().body( "{\"email\":\"F@Y.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "country", "J")
+            .cookie( "region", "&")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":null,\"email\":\"+@J.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "country", "#")
+            .cookie( "region", "$")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"JPt TLg/#+P9F03USC(F12J)k+BE<&oGTJh<RrmNe6-yTg=G<?qA\\\\MHn+L:c\\\"B7~'\",\"email\":\"q@2.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "O")
+            .cookie( "region", "6")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"g@I.org\",\"qlrcnlkwzq\":\"[oIUO\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "postId", "A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_2() {
+        given()
+            .cookie( "postId", "B|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_C() {
+        given()
+            .cookie( "postId", "C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_No() {
+        given()
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_NotArray() {
+        given()
+            .cookie( "postId", "568.0")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_0() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_3() {
+        given()
+            .cookie( "postId", "A|B|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsType_Is_Null() {
+        given()
+            .cookie( "postId", "|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_Other() {
+        given()
+            .cookie( "postId", "jLId'31*^UjExCZerfw#(S_b#m[(L&~c@x{Xp7Btyr+R+'p[jrH_o$X`LnQgI'mW?MxXRGcS[=P2R2jAx5z4OLaEDo=8cde$AvZR#F#0>Z[cld8Em_%vE!{(9$+z!(Ghc.{J[m^1HdT/7PKLdR0v:@srfapHf(c/l2s&<{QFg8oMlvF<0@dbS:.5ef?WOZ+>MHIUD-{?yH$5-DM3*T>hR%ct'(7EzCR]8|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsUnique_Is_No() {
+        given()
+            .cookie( "postId", "A|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_UsersTest.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_5-Expected/Results_UsersTest.java
@@ -1,0 +1,29 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class Results_UsersTest {
+
+    @Test
+    public void getUsers() {
+        given()
+        .when()
+            .request( "GET", "/users")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_6-Expected-Test.java
+++ b/tcases-cli/src/test/resources/org/cornutum/tcases/openapi/byPath_6-Expected-Test.java
@@ -1,0 +1,2404 @@
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostsTest {
+
+    @Test
+    public void getPosts_IdsDefined_Is_Yes() {
+        given()
+            .queryParam( "ids", "0")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_4() {
+        given()
+            .queryParam( "ids", "100|35|31|12")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsDefined_Is_No() {
+        given()
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsType_Is_NotArray() {
+        given()
+            .queryParam( "ids", "-6")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_0() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsSize_Is_5() {
+        given()
+            .queryParam( "ids", "0|80|63|32|91")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Size=5
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "ids", "")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_M1() {
+        given()
+            .queryParam( "ids", "-1")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsContainsValue_Is_101() {
+        given()
+            .queryParam( "ids", "101")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Contains.Value.Is=101
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void getPosts_IdsItemsUnique_Is_No() {
+        given()
+            .queryParam( "ids", "0|33|92|92")
+        .when()
+            .request( "GET", "/posts")
+        .then()
+            // ids.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_Yes() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_2345() {
+        given()
+            .header( "X-Post-Types", "2345,7700")
+            .header( "X-User-Id", "46782787")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_7700() {
+        given()
+            .header( "X-Post-Types", "7700,2345")
+            .header( "X-User-Id", "0")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesDefined_Is_No() {
+        given()
+            .header( "X-User-Id", "1002717876")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "295907700")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesType_Is_NotArray() {
+        given()
+            .header( "X-Post-Types", "")
+            .header( "X-User-Id", "940566730")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_1() {
+        given()
+            .header( "X-Post-Types", "1001")
+            .header( "X-User-Id", "995957995")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsSize_Is_3() {
+        given()
+            .header( "X-Post-Types", "1001,2345,7700")
+            .header( "X-User-Id", "543574415")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_Null() {
+        given()
+            .header( "X-Post-Types", ",7700")
+            .header( "X-User-Id", "324488672")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "_0>6l,1001")
+            .header( "X-User-Id", "156012952")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsContainsValue_Is_Other() {
+        given()
+            .header( "X-Post-Types", "260738342,1001")
+            .header( "X-User-Id", "330205658")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XPostTypesItemsUnique_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,1001")
+            .header( "X-User-Id", "287469117")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-Post-Types.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdDefined_Is_No() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_Null() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", "")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdType_Is_NotInteger() {
+        given()
+            .header( "X-Post-Types", "1001,2345")
+            .header( "X-User-Id", ";UA")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void optionsPosts_XUserIdValue_Is_M1() {
+        given()
+            .header( "X-Post-Types", "1001,7700")
+            .header( "X-User-Id", "-1")
+        .when()
+            .request( "OPTIONS", "/posts")
+        .then()
+            // X-User-Id.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_Yes() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"m@W.com\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedValue_Is_False() {
+        given()
+            .cookie( "approved", "false")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_32() {
+        given()
+            .cookie( "approved", "true")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"ezMe2&I.\\\"aMq>yn}=%E|qk,BL`=d\\\\',p6z*[3:hJZwGvOPrjzu61{$ek@KVCB]|8\",\"email\":\"2.6.=.&.?.K.I.s.!@7sq9.96wcX.edu\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedDefined_Is_No() {
+        given()
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_Null() {
+        given()
+            .cookie( "approved", "")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_ApprovedType_Is_NotBoolean() {
+        given()
+            .cookie( "approved", "g<h[(2")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/xml")
+            .request().body( "{\"yqjvfkkbpw\":-423.0,\"lnyiywnpwriprxz\":-902}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "null")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonType_Is_NotObject() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "709.7")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":37.6}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"Jm.gov\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"QLv?Bb963Fs.YrQLFE;nR~eE@6w6O.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"email\":\"2@N.org\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":null,\"email\":\"+@A.com\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextType_Is_NotString() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":true,\"email\":\"r@S.edu\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Type=Not string
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\",XM8YB6+me$jhjpa5B#QsXRRyK4s=zT)f_fpwYXqdu21?A] 5t8uZe7$5NG0Wed b\",\"email\":\"z@I.net\"}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void postPosts_BodyApplicationJsonValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "approved", "false")
+            .contentType( "application/json")
+            .request().body( "{\"text\":\"\",\"email\":\"o@g.gov\",\"oychp\":-638.3,\"iimkfycd\":[],\"kuhhctjnrda\":805}")
+        .when()
+            .request( "POST", "/posts")
+        .then()
+            // Body.application-json.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "country", "I")
+            .cookie( "region", "W")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"0@p.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_16() {
+        given()
+            .cookie( "country", ":IEt|~VjQA_R}TA(")
+            .cookie( "region", "#:iPPHOumVFtB^@r")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"JFQM3N>B1#lB/U{OHId-;1^nGH1l+ah#,#![^s\\\\brAMrXLB\\\\ u$[V><]\\\"dv*RKO;\",\"email\":\"GJ@W.kds.PHn.7DP.5GF.aNX.OZp.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdDefined_Is_No() {
+        given()
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"R@L.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"B@N.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdType_Is_NotObject() {
+        given()
+            .cookie( "postId", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"r@i.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryDefined_Is_No() {
+        given()
+            .cookie( "region", "h")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"*@3.net\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryType_Is_Null() {
+        given()
+            .cookie( "country", "")
+            .cookie( "region", "k")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"l@u.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesCountryValueLength_Is_17() {
+        given()
+            .cookie( "country", "GF:-Al}%h'$N)k5Nn")
+            .cookie( "region", "#")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"=@O.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.country.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionDefined_Is_No() {
+        given()
+            .cookie( "country", "b")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"{@V.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionType_Is_Null() {
+        given()
+            .cookie( "country", "[")
+            .cookie( "region", "")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"v@S.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesRegionValueLength_Is_17() {
+        given()
+            .cookie( "country", ".")
+            .cookie( "region", ")dzW[S-YC=k7?yx?K")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"U@z.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.region.Value.Length=17
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_PostIdValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "%")
+            .cookie( "region", "T")
+            .cookie( "fvwfwnxkmrev", "true")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"A@3.edu\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // postId.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyDefined_Is_No() {
+        given()
+            .cookie( "country", "c")
+            .cookie( "region", "t")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyMediaType_Is_Other() {
+        given()
+            .cookie( "country", "I")
+            .cookie( "region", "~")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "boolean", "true")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_Null() {
+        given()
+            .cookie( "country", "O")
+            .cookie( "region", "+")
+            .contentType( "text/plain")
+            .request().body( "null")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainType_Is_NotObject() {
+        given()
+            .cookie( "country", "?")
+            .cookie( "region", "@")
+            .contentType( "text/plain")
+            .request().body( "193")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailDefined_Is_No() {
+        given()
+            .cookie( "country", "w")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailType_Is_Null() {
+        given()
+            .cookie( "country", "[")
+            .cookie( "region", "?")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":null}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_6() {
+        given()
+            .cookie( "country", "@")
+            .cookie( "region", "x")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"j6.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=6
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesEmailValueLength_Is_33() {
+        given()
+            .cookie( "country", "$")
+            .cookie( "region", "l")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"|7Gr.Ptv.A'U@r.Cn3N.o79T.57vS.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.email.Value.Length=33
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextDefined_Is_No() {
+        given()
+            .cookie( "country", "D")
+            .cookie( "region", "s")
+            .contentType( "text/plain")
+            .request().body( "{\"email\":\"q@L.com\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextType_Is_Null() {
+        given()
+            .cookie( "country", "s")
+            .cookie( "region", "n")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":null,\"email\":\"j@4.gov\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesTextValueLength_Is_65() {
+        given()
+            .cookie( "country", "Y")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"S:Y2'%=]f[\\\"jLb$%[]\\\\ae(_<-<MP\\\\f~(Qe)c#9}P`CkQ <[8liE&[lM(raFH&GF3.\",\"email\":\"=@3.org\"}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.text.Value.Length=65
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPosts_BodyTextPlainValuePropertiesAdditional_Is_Yes() {
+        given()
+            .cookie( "country", "h")
+            .cookie( "region", "{")
+            .contentType( "text/plain")
+            .request().body( "{\"text\":\"\",\"email\":\"t@d.gov\",\"mnxgkkxm\":-180}")
+        .when()
+            .request( "PUT", "/posts")
+        .then()
+            // Body.text-plain.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_Yes() {
+        given()
+            .cookie( "postId", "A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_2() {
+        given()
+            .cookie( "postId", "B|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_C() {
+        given()
+            .cookie( "postId", "C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdDefined_Is_No() {
+        given()
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_Null() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdType_Is_NotArray() {
+        given()
+            .cookie( "postId", "true")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_0() {
+        given()
+            .cookie( "postId", "")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsSize_Is_3() {
+        given()
+            .cookie( "postId", "A|C|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsType_Is_Null() {
+        given()
+            .cookie( "postId", "|B")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsContainsValue_Is_Other() {
+        given()
+            .cookie( "postId", "3=rI:rH7jvN+>LNx0M#eAmB3|C")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePosts_PostIdItemsUnique_Is_No() {
+        given()
+            .cookie( "postId", "A|A")
+        .when()
+            .request( "TRACE", "/posts")
+        .then()
+            // postId.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostsUseridAttributesTest {
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=0")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_Gt_0() {
+        given()
+            .pathParam( "[attributes]", "approved=false")
+            .pathParam( "userId", "681271971")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "[attributes]", "likes=706422332")
+            .pathParam( "userId", "0")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true")
+            .pathParam( "userId", "-1")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "619183171")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "[attributes]", "%(ER,e{PU,Yw|Re")
+            .pathParam( "userId", "1030958588")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertyCount_Is_Lt_1() {
+        given()
+            .pathParam( "[attributes]", "")
+            .pathParam( "userId", "1037528634")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Property-Count=< 1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=")
+            .pathParam( "userId", "965022493")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "[attributes]", "approved=iodyhmr,true,osoeucjjcbyfuju,-215")
+            .pathParam( "userId", "909733668")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=")
+            .pathParam( "userId", "551606192")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=w")
+            .pathParam( "userId", "338978897")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "[attributes]", "approved=true,likes=-1")
+            .pathParam( "userId", "1010487514")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostsUserIdAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "[attributes]", "approved=true,cfpdruj=v6=k\"yI")
+            .pathParam( "userId", "726508116")
+        .when()
+            .request( "DELETE", "/posts/{userId}/{[attributes]}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostsAttributesTest {
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=A Day In Hell;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedValue_Is_False() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=514682280")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_WhatMeWorry() {
+        given()
+            .pathParam( "attributes", ";approved=true;subject=What? Me, worry?;likes=0")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", "")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";attributes")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesType_Is_NotObject() {
+        given()
+            .pathParam( "attributes", ";attributes=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";likes=640659892")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=;likes=835347369")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .pathParam( "attributes", ";approved=ltgjsaarufjsntz,39.8,nmjvnsa,-388.5,asyxuquvohcwtz,true;likes=6787962")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesDefined_Is_No() {
+        given()
+            .pathParam( "attributes", ";approved=false")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesType_Is_NotInteger() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=-663.1")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesLikesValue_Is_M1() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=-1")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.likes.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectType_Is_Null() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=;likes=187325925")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesSubjectValue_Is_Other() {
+        given()
+            .pathParam( "attributes", ";approved=false;subject=(/fQ+iXAv6[oToMT*B60a#-lu2U[ 6M~/]G8te^x?ev/ZGRSe'o_7G'lT6n:2 TGq64S?G55LA}?\"nCf4bt)Jda:O-1JP/r\\#*;DZkLr}5v=:[OgEJkwNsAWd#w{=acXgFE}K+}U5Hk5KT'maYikYsS{R$VAC2mS{:D/I~Sd\"%HcE.3j|/& #e2Ak5-H52vY6QA-FsF|~nyK9bCaxM.}DpZ%9,j].;likes=831591488")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.subject.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void tracePostsAttributes_AttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .pathParam( "attributes", ";approved=false;likes=803777274;i=")
+        .when()
+            .request( "TRACE", "/posts/{attributes}")
+        .then()
+            // attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostTest {
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_VIP() {
+        given()
+            .queryParam( "post?[post-references]", "1,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_2() {
+        given()
+            .queryParam( "post?[post-references]", "2,1")
+            .queryParam( "user attributes[user-type]", "Typical User")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesType_Is_NotObject() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes", "-699.6")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeDefined_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "user attributes[user-type]", "")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesUserTypeValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "{vz0c([_F@'\"4E%yI=i)s.g=LFn%SSq.4M?.g1-W >AuVibu1b4au-fF<6rX)7MIH:y(/?E+6{os~)X2veU]-%v!0p/pC !G%wgsK)'HA(>Wv&C\"|in~2p?-0IC4RyPhoL$Q\\|1$S)\\>_")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.user-type.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_UserAttributesValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+            .queryParam( "user attributes[ucvn]", "true")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // user-attributes.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_Null() {
+        given()
+            .queryParam( "post?", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostType_Is_NotObject() {
+        given()
+            .queryParam( "post?", "638")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesDefined_Is_No() {
+        given()
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesType_Is_NotArray() {
+        given()
+            .queryParam( "post?[post-references]", "-224")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_1() {
+        given()
+            .queryParam( "post?[post-references]", "0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsSize_Is_3() {
+        given()
+            .queryParam( "post?[post-references]", "0,1,2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Size=3
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "post?[post-references]", ",2")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsType_Is_NotInteger() {
+        given()
+            .queryParam( "post?[post-references]", ",\")j\\}|,?+hI|y,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "post?[post-references]", "-8421636,1")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Contains.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesPostReferencesItemsUnique_Is_No() {
+        given()
+            .queryParam( "post?[post-references]", "0,0")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.post-references.Items.Unique=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void headPost_PostValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "post?[post-references]", "0,2")
+            .queryParam( "post?[knd]", "")
+            .queryParam( "user attributes[user-type]", "VIP!")
+        .when()
+            .request( "HEAD", "/post")
+        .then()
+            // post.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_Yes() {
+        given()
+            .queryParam( "Post Marks", "{X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_3() {
+        given()
+            .queryParam( "Post Marks", "<Y> {X} #Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Z() {
+        given()
+            .queryParam( "Post Marks", "#Z")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsUnique_Is_No() {
+        given()
+            .queryParam( "Post Marks", "{X} {X} <Y>")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksDefined_Is_No() {
+        given()
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksType_Is_NotArray() {
+        given()
+            .queryParam( "Post Marks", "403.3")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Type=Not array
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_0() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=0
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsSize_Is_4() {
+        given()
+            .queryParam( "Post Marks", "<Y> #Z {X} {X}")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Size=4
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsType_Is_Null() {
+        given()
+            .queryParam( "Post Marks", "")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void patchPost_PostMarksItemsContainsValue_Is_Other() {
+        given()
+            .queryParam( "Post Marks", "b}(U6Xfe`>]?lpy,CJQd6kIkW_U+H3/98854vP.[y}R5y!2%3%_Y/'1\\(~|,)qXKnH")
+        .when()
+            .request( "PATCH", "/post")
+        .then()
+            // Post-Marks.Items.Contains.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_Yes() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_Gt_0() {
+        given()
+            .queryParam( "postId", "803445276551147189.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "(?)")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_MeYou() {
+        given()
+            .queryParam( "postId", "0")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "true")
+            .formParam( "reviewer", "Me+You")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdDefined_Is_No() {
+        given()
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_Null() {
+        given()
+            .queryParam( "postId", "")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdType_Is_NotNumber() {
+        given()
+            .queryParam( "postId", ")eC^@^\\A")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Type=Not number
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_PostIdValue_Is_M1() {
+        given()
+            .queryParam( "postId", "-1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // postId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyDefined_Is_No() {
+        given()
+            .queryParam( "postId", "856313282084416394.1")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyMediaType_Is_Other() {
+        given()
+            .queryParam( "postId", "515349763337368011.7")
+            .contentType( "text/xml")
+            .request().body( "-859.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.Media-Type=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_Null() {
+        given()
+            .queryParam( "postId", "507487423726193757.6")
+            .contentType( "application/x-www-form-urlencoded")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedType_Is_NotObject() {
+        given()
+            .queryParam( "postId", "915631707044085407.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "number", "5.4")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Type=Not object
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedDefined_Is_No() {
+        given()
+            .queryParam( "postId", "338691171953762326.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_Null() {
+        given()
+            .queryParam( "postId", "478596007308032957.7")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesApprovedType_Is_NotBoolean() {
+        given()
+            .queryParam( "postId", "420095667913229974.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "")
+            .formParam( "reviewer", "Larry Moe")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.approved.Type=Not boolean
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerDefined_Is_No() {
+        given()
+            .queryParam( "postId", "94273501035354036.6")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerType_Is_Null() {
+        given()
+            .queryParam( "postId", "597422243307448674.8")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesReviewerValue_Is_Other() {
+        given()
+            .queryParam( "postId", "616970863794345540.5")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", ":zpa1JvdLE;q5~*.^/XIYik~:\"sH!Tr2kV)X*(]mZ]8' ")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.reviewer.Value=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void putPost_BodyApplicationXWwwFormUrlencodedValuePropertiesAdditional_Is_Yes() {
+        given()
+            .queryParam( "postId", "377378332398273490.1")
+            .contentType( "application/x-www-form-urlencoded")
+            .formParam( "approved", "false")
+            .formParam( "reviewer", "Larry Moe")
+            .formParam( "lezmvljb", "true")
+            .formParam( "cdrlletpkaho", "562")
+            .formParam( "xrlwx", "S,_9,W}W")
+        .when()
+            .request( "PUT", "/post")
+        .then()
+            // Body.application-x-www-form-urlencoded.Value.Properties.Additional=Yes
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_PostUseridApprovedTest {
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_Yes() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1000() {
+        given()
+            .pathParam( "approved", ".1")
+            .pathParam( "userId", ".1000")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdDefined_Is_No() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", "")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_Null() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".248.1")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_M1() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".-1")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=-1
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_UserIdValue_Is_1001() {
+        given()
+            .pathParam( "approved", ".0")
+            .pathParam( "userId", ".1001")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // userId.Value.Is=1001
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedDefined_Is_No() {
+        given()
+            .pathParam( "approved", "")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Defined=No
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_Null() {
+        given()
+            .pathParam( "approved", ".")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=null
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedType_Is_NotInteger() {
+        given()
+            .pathParam( "approved", ".")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Type=Not integer
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    @Test
+    public void deletePostUserIdApproved_ApprovedValue_Is_Other() {
+        given()
+            .pathParam( "approved", ".925787165")
+            .pathParam( "userId", ".0")
+        .when()
+            .request( "DELETE", "/post/{userId}/{approved}")
+        .then()
+            // approved.Value.Is=Other
+            .statusCode( isBadRequest())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}
+package org.cornutum.examples;
+
+
+import org.junit.Test;
+
+import org.hamcrest.Matcher;
+import static io.restassured.RestAssured.*;
+import static org.hamcrest.Matchers.*;
+
+public class OpenAPIRequestTestCases_UsersTest {
+
+    @Test
+    public void getUsers() {
+        given()
+        .when()
+            .request( "GET", "/users")
+        .then()
+            .statusCode( isSuccess())
+            ;
+    }
+
+    private Matcher<Integer> isSuccess() {
+        return allOf( greaterThanOrEqualTo(200), lessThan(300));
+    }
+
+    private Matcher<Integer> isBadRequest() {
+        return allOf( greaterThanOrEqualTo(400), lessThan(500));
+    }
+}

--- a/tcases-cli/src/test/tcases/org/cornutum/tcases/openapi/ApiTestCommand-ByPath-Generators.xml
+++ b/tcases-cli/src/test/tcases/org/cornutum/tcases/openapi/ApiTestCommand-ByPath-Generators.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<Generators>
+  <TupleGenerator function="run" seed="6640525937333307392" tuples="1">
+    <Combine tuples="2">
+      <Include var="Output-Dir.Defined"/>
+      <Include var="Output-File.Defined"/>
+      <Include var="Test-Name"/>
+    </Combine>
+  </TupleGenerator>
+</Generators>

--- a/tcases-cli/src/test/tcases/org/cornutum/tcases/openapi/ApiTestCommand-ByPath-Input.xml
+++ b/tcases-cli/src/test/tcases/org/cornutum/tcases/openapi/ApiTestCommand-ByPath-Input.xml
@@ -1,0 +1,41 @@
+<System name="ApiTestCommand">
+    <Function name="run">
+        <Input>
+            <Var name="ByPath">
+                <Value name="Yes"/>
+            </Var>
+            <Var name="Test-Name">
+                <Value name="Default"/>
+                <Value name="Simple"/>
+                <Value name="Fqn" property="testNameFqn"/>
+            </Var>
+            <VarSet name="Output-File">
+                <Var name="Defined">
+                    <Value name="Yes" property="outputFile"/>
+                    <Value name="No"/>                    
+                </Var>
+                <Var name="Path" when="outputFile">
+                    <Value name="Relative"/>
+                    <Value name="Absolute"/>
+                </Var>
+            </VarSet>
+            <VarSet name="Output-Dir">
+                <Var name="Defined">
+                    <Value name="Yes" property="outputDir"/>
+                    <Value name="No"/>                    
+                </Var>
+            </VarSet>
+            <Var name="Paths">
+                <Value name="Default"/>
+                <Value name="One"/>
+                <Value name="Many"/>
+            </Var>
+            <VarSet name="Api-Spec">
+                <Var name="Defined">
+                    <Value name="Yes" property="apiSpec"/>
+                    <Value name="No"/>                    
+                </Var>
+            </VarSet>
+        </Input>
+    </Function>
+</System>

--- a/tcases-maven-plugin/src/main/java/org/cornutum/tcases/maven/ApiTestMojo.java
+++ b/tcases-maven-plugin/src/main/java/org/cornutum/tcases/maven/ApiTestMojo.java
@@ -87,6 +87,7 @@ public class ApiTestMojo extends AbstractMojo
         options.setBaseClass( getBaseClass());
         options.setTimeout( getTimeout());
         options.setMocoTestConfig( getMocoTestConfigFile());
+        options.setByPath( getByPath());
         options.setPaths( getPaths());
         options.setOperations( getOperations());
         options.setContentType( getContentType());
@@ -453,6 +454,24 @@ public class ApiTestMojo extends AbstractMojo
     }
 
   /**
+   * If true, a separate test file is generated for each of the API resource paths specified by the {@link #getPaths} option,
+   * each containing tests for a single path. Otherwise, a single test file is generated containing tests for all paths.
+   */
+  public void setByPath( boolean byPath)
+    {
+    this.byPath = byPath;
+    }
+
+  /**
+   * If true, a separate test file is generated for each of the API resource paths specified by the {@link #getPaths} option,
+   * each containing tests for a single path. Otherwise, a single test file is generated containing tests for all paths.
+   */
+  public boolean getByPath()
+    {
+    return byPath;
+    }
+
+  /**
    * Changes request paths for which tests are generated.
    */
   public void setPaths( Set<String> paths)
@@ -621,6 +640,13 @@ public class ApiTestMojo extends AbstractMojo
    */
   @Parameter(property="mocoTestConfig")
   private String mocoTestConfig;
+
+  /**
+   * If true, a separate test file is generated for each of the API resource paths specified by the <B><CODE>paths</CODE></B> option,
+   * each containing tests for a single path. Otherwise, a single test file is generated containing tests for all paths.
+   */
+  @Parameter(property="byPath",defaultValue="false")
+  private boolean byPath;
 
   /**
    * If defined, tests are generated only for the specified API resource paths. 

--- a/tcases-maven-plugin/src/test/java/org/cornutum/tcases/maven/ApiTestMojoTest.java
+++ b/tcases-maven-plugin/src/test/java/org/cornutum/tcases/maven/ApiTestMojoTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.*;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Runs tests for the {@link ApiTestMojo} plugin.
@@ -40,6 +41,32 @@ public class ApiTestMojoTest extends AbstractMojoTest
     assertThat( "Out dir", apiTestMojo.getOutDirFile(), is( expectedOutDir));
 
     List<String> expectedTests = Arrays.asList( "org/cornutum/api/MyTest.java");
+    assertThat( "Tests", Arrays.asList( findPathsMatching( expectedOutDir, "**/*")), containsMembers( expectedTests));
+    }
+  
+  @Test
+  public void execute_byPath() throws Exception
+    {
+    // Given...
+    File baseDirTest = getBaseDirTest( "api-test-project-byPath");
+
+    // When...
+    ApiTestMojo apiTestMojo = (ApiTestMojo) mojoHelper.lookupConfiguredMojo( baseDirTest, "api-test");
+    clean( apiTestMojo.getOutDirFile());
+    apiTestMojo.execute();
+
+    // Then...
+    File expectedInputDir = new File( baseDirTest, "src/test/tcases/openapi");
+    assertThat( "Input dir", apiTestMojo.getInputDirFile(), is( expectedInputDir));
+
+    File expectedOutDir = new File( baseDirTest, "target/generated-test-sources/java");
+    assertThat( "Out dir", apiTestMojo.getOutDirFile(), is( expectedOutDir));
+
+    List<String> expectedTests =
+      Arrays.asList( "Post", "Posts", "Users")
+      .stream()
+      .map( path -> String.format( "org/cornutum/api/OpenAPIRequestTestCases_%sTest.java", path))
+      .collect( toList());
     assertThat( "Tests", Arrays.asList( findPathsMatching( expectedOutDir, "**/*")), containsMembers( expectedTests));
     }
   

--- a/tcases-maven-plugin/src/test/resources/api-test-project-byPath/pom.xml
+++ b/tcases-maven-plugin/src/test/resources/api-test-project-byPath/pom.xml
@@ -1,0 +1,33 @@
+<project 
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.cornutum.tcases</groupId>
+  <artifactId>api-test-project-byPath</artifactId>
+  <version>3.4.0</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.cornutum.tcases</groupId>
+        <artifactId>tcases-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+            <byPath>true</byPath>
+            <paths>
+                <path>/post</path>
+                <path>/posts</path>
+                <path>/users</path>
+            </paths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/tcases-maven-plugin/src/test/resources/api-test-project-byPath/src/test/tcases/openapi/org/cornutum/api/OpenApiTest.json
+++ b/tcases-maven-plugin/src/test/resources/api-test-project-byPath/src/test/tcases/openapi/org/cornutum/api/OpenApiTest.json
@@ -1,0 +1,534 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "OpenAPI Request Test Cases",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/posts": {
+            "trace": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [ "A", "B", "C"]
+                            },
+                            "minItems": 1,
+                            "maxItems": 2,
+                            "uniqueItems": true
+                        },
+                        "example": [ "A", "C"]
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "options": {
+                "parameters": [
+                    {
+                        "name": "X-Post-Types",
+                        "required": true,
+                        "in": "header",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "enum": [ 1001, 2345, 7700 ]
+                            },
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "uniqueItems": true
+                        },
+                        "examples": {
+                            "1": { "value": [ 1001, 2345 ]},
+                            "2": { "value": [ 7700, 2345 ]},
+                            "3": { "value": [ 1001, 7700 ]}
+                        }
+                    },
+                    {
+                        "name": "X-User-Id",
+                        "required": true,
+                        "in": "header",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "example": 255
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "post": {
+                "parameters": [
+                    {
+                        "name": "approved",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "maxLength": 32
+                                    },
+                                    "text": {
+                                        "type": "string",
+                                        "minLength": 0,
+                                        "maxLength": 64
+                                    }
+                                },
+                                "required": [ "email", "text" ],
+                                "additionalProperties": false
+                            },
+                            "examples": {
+                                "1": { "value": {"email": "howdy@hello.com", "text": ""}},
+                                "2": { "value": {"email": "hi@hello.com", "text": "informal"}},
+                                "3": { "value": {"email": "hola@hello.com", "text": "jaunty"}}
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "get": {
+                "parameters": [
+                    {
+                        "name": "ids",
+                        "required": true,
+                        "in": "query",
+                        "style": "pipeDelimited",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 100
+                            },
+                            "minItems": 1,
+                            "maxItems": 4,
+                            "uniqueItems": true,
+                            "example": [ 50 ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+
+            "put": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "cookie",
+                        "style": "form",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "country": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 16
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 16
+                                }
+                            },
+                            "required": [ "country", "region" ],
+                            "additionalProperties": false
+                        },
+                        "example": {"country": "USA", "region": "West"}
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "text/plain": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "maxLength": 32
+                                    },
+                                    "text": {
+                                        "type": "string",
+                                        "minLength": 0,
+                                        "maxLength": 64
+                                    }
+                                },
+                                "required": [ "email", "text" ],
+                                "additionalProperties": false,
+                                "example": {"email": "hello@hello.com", "text": "standard"}
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/posts/{userId}/{[attributes]}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "required": true,
+                        "in": "path",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "examples": {
+                            "1": { "value": 1 },
+                            "2": { "value": 22 },
+                            "3": { "value": 3333 }
+                        }
+                    },
+                    {
+                        "name": "[attributes]",
+                        "required": true,
+                        "in": "path",
+                        "style": "simple",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "approved": {
+                                    "type": "boolean"
+                                },
+                                "likes": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "example": 12345
+                                }
+                            },
+                            "minProperties": 1,
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+
+        "/posts/{attributes}": {
+            "trace": {
+                "parameters": [
+                    {
+                        "name": "attributes",
+                        "required": true,
+                        "in": "path",
+                        "style": "matrix",
+                        "explode": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "approved": {
+                                    "type": "boolean"
+                                },
+                                "likes": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "subject": {
+                                    "type": "string",
+                                    "enum": [ "A Day In Hell", "What? Me, worry?" ]
+                                }
+                            },
+                            "required": [ "approved", "likes" ],
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/post": {
+            "put": {
+                "parameters": [
+                    {
+                        "name": "postId",
+                        "required": true,
+                        "in": "query",
+                        "style": "form",
+                        "explode": false,
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0
+                        },
+                        "examples": {
+                            "1": { "value": 1.23 },
+                            "2": { "value": -456.78 },
+                            "3": { "value": 9.01 }
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "approved": {
+                                        "type": "boolean"
+                                    },
+                                    "reviewer": {
+                                        "type": "string",
+                                        "enum": [ "Larry Moe", "(?)", "Me+You"]
+                                    }
+                                },
+                                "required": [ "approved", "reviewer" ],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+
+            "head": {
+                "parameters": [
+                    {
+                        "name": "user attributes",
+                        "required": true,
+                        "in": "query",
+                        "style": "deepObject",
+                        "explode": false,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user type": {
+                                    "type": "string",
+                                    "enum": [ "Typical User", "VIP!" ]
+                                }
+                            },
+                            "required": [ "user type" ],
+                            "additionalProperties": false
+                        }
+                    },
+                    {
+                        "name": "post?",
+                        "required": true,
+                        "in": "query",
+                        "style": "deepObject",
+                        "explode": false,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "post references": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer",
+                                        "enum": [ 0, 1, 2 ]
+                                    },
+                                    "minItems": 2,
+                                    "maxItems": 2,
+                                    "uniqueItems": true
+                                }
+                            },
+                            "required": [ "post references" ],
+                            "additionalProperties": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            },
+            
+            "patch": {
+                "parameters": [
+                    {
+                        "name": "Post Marks",
+                        "required": true,
+                        "in": "query",
+                        "style": "spaceDelimited",
+                        "explode": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [ "{X}", "<Y>", "#Z" ]
+                            },
+                            "minItems": 1,
+                            "maxItems": 3
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        },
+        
+        "/post/{userId}/{approved}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "required": true,
+                        "in": "path",
+                        "style": "label",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 1000
+                        },
+                        "example": 999
+                    },
+                    {
+                        "name": "approved",
+                        "required": true,
+                        "in": "path",
+                        "style": "label",
+                        "explode": false,
+                        "schema": {
+                            "type": "integer",
+                            "enum": [ 0, 1 ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "requestBodies": {
+            "standard": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "responses": {
+            "success": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "failure": {
+                "description": "Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tcases-openapi/src/main/java/org/cornutum/tcases/openapi/testwriter/TestWriter.java
+++ b/tcases-openapi/src/main/java/org/cornutum/tcases/openapi/testwriter/TestWriter.java
@@ -101,7 +101,7 @@ public abstract class TestWriter<S extends TestSource, T extends TestTarget>
   /**
    * Returns the test name derived from the given source and target.
    */
-  protected String getTestName( S source, T target)
+  public String getTestName( S source, T target)
     {
     return
       getTestName(


### PR DESCRIPTION
Fixes issue #168 

For shell command `tcases-api-test`,  adds a new option `-S` (alternatively, for Maven goal `tcases:api-test`, the `byPaths` option). If specified, a separate test file is generated for each of the API resource paths specified by the -P option, each containing tests for a single path. Otherwise, a single test file is generated containing tests for all paths.