### PR TITLE
Generate "not multiple" failure cases correctly

### DIFF
--- a/tcases-lib/src/main/java/org/cornutum/tcases/resolve/DecimalDomain.java
+++ b/tcases-lib/src/main/java/org/cornutum/tcases/resolve/DecimalDomain.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toSet;
@@ -177,6 +178,14 @@ public class DecimalDomain extends NumberDomain<BigDecimal>
     }
 
   /**
+   * Returns true if <CODE>value</CODE> is a multiple of any member of the <CODE>multiples</CODE>.
+   */
+  private boolean isMultipleOf( BigDecimal value, Set<BigDecimal> multiples)
+    {
+    return multiples.stream().anyMatch( multiple -> isMultipleOf( value, multiple));
+    }
+
+  /**
    * Returns a random sequence of values from this domain.
    */
   @Override
@@ -190,7 +199,7 @@ public class DecimalDomain extends NumberDomain<BigDecimal>
     
     BigDecimal unit;
     for( unit = new BigDecimal( BigInteger.ONE, unitScale);
-         getNotMultipleOfs().contains( unit);
+         isMultipleOf( unit, getNotMultipleOfs());
          unit = new BigDecimal( BigInteger.ONE, ++unitScale));
 
     // Find smallest and largest (multiples) in range

--- a/tcases-lib/src/test/java/org/cornutum/tcases/resolve/TestCaseSchemaResolverTest.java
+++ b/tcases-lib/src/test/java/org/cornutum/tcases/resolve/TestCaseSchemaResolverTest.java
@@ -236,7 +236,7 @@ public class TestCaseSchemaResolverTest extends ResolverTest
         .name( "Parent.Var='String'")
         .bind(
           VarBindingBuilder.with( "Parent.Var")
-          .value( "2022-08-29T16:05:42.931-05:00")
+          .value( "2023-08-29T16:05:42.931-05:00")
           .source( "String")
           .has( "format", "date-time")
           .build())
@@ -493,7 +493,7 @@ public class TestCaseSchemaResolverTest extends ResolverTest
         .name( "Parent.Var='String'")
         .bind(
           VarBindingBuilder.with( "Parent.Var")
-          .value( "2022-07-05")
+          .value( "2023-07-05")
           .source( "String")
           .has( "format", "date")
           .build())
@@ -584,7 +584,7 @@ public class TestCaseSchemaResolverTest extends ResolverTest
         .name( "Var='String'")
         .bind(
           VarBindingBuilder.with( "Var")
-          .value( "2022-08-29T16:05:42.931-05:00")
+          .value( "2023-08-29T16:05:42.931-05:00")
           .source( "String")
           .has( "format", "date-time")
           .build())

--- a/tcases-openapi/src/main/java/org/cornutum/tcases/openapi/InputModeller.java
+++ b/tcases-openapi/src/main/java/org/cornutum/tcases/openapi/InputModeller.java
@@ -2128,10 +2128,15 @@ public abstract class InputModeller extends ContextHandler<OpenApiContext>
         if( multipleOf != null)
           {
           // Select a value within bounds that fails the multiple-of constraint.
+          BigDecimal notMultipleUnit =
+            isMultipleOf( unit, multipleOf)
+            ? new BigDecimal( BigInteger.ONE, multipleOf.scale() + 1)
+            : unit;
+          
           BigDecimal multipleOfFailure;
-          for( multipleOfFailure = effectiveMinimum.add( unit);
+          for( multipleOfFailure = effectiveMinimum.add( notMultipleUnit);
                multipleOfFailure.compareTo( maximum) < 0 && isMultipleOf( multipleOfFailure, multipleOf);
-               multipleOfFailure = multipleOfFailure.add( unit));
+               multipleOfFailure = multipleOfFailure.add( notMultipleUnit));
           if( multipleOfFailure.compareTo( maximum) < 0)
             {
             quantity.values(

--- a/tcases-openapi/src/test/java/org/cornutum/tcases/openapi/NumberSchemaTest.java
+++ b/tcases-openapi/src/test/java/org/cornutum/tcases/openapi/NumberSchemaTest.java
@@ -254,4 +254,13 @@ public class NumberSchemaTest extends OpenApiTest
     {
     verifyRequestInputModel( "number-9");
     }
+
+  /**
+   * Verifies {@link TcasesOpenApi#getRequestInputModel getRequestInputModel} for issue 285.
+   */
+  @Test
+  public void Schema_285()
+    {
+    verifyRequestInputModel( "number-285");
+    }
   }

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/not-4-Expected-Input.xml
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/not-4-Expected-Input.xml
@@ -65,6 +65,7 @@
                 <Value name="11.0" failure="true"/>
                 <Value name="99.9"/>
                 <Value name="100.0" failure="true"/>
+                <Value name="0.01" failure="true"/>
               </Var>
             </VarSet>
           </VarSet>

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/not-4-Expected-Test.xml
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/not-4-Expected-Test.xml
@@ -816,7 +816,54 @@
         </Var>
       </Input>
     </TestCase>
-    <TestCase id="17" failure="true" name="param0.Alternative.2.Value.Multiple-Of.7d5=&apos;Yes&apos;">
+    <TestCase id="17" failure="true" name="param0.Alternative.1.Value.Is=&apos;0.01&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/not"/>
+      <Has name="properties" value="param0,param0Alternative1,param0Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Not"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Alternative.Used" value="1">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.0.Value.Multiple-Of.0d1" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.0.Value.Multiple-Of.2d0" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.1.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.1.Value.Is" value="0.01" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.2.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.2.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.2.Value.Multiple-Of.0d1" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Alternative.2.Value.Multiple-Of.7d5" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="18" failure="true" name="param0.Alternative.2.Value.Multiple-Of.7d5=&apos;Yes&apos;">
       <Has name="operation" value="POST"/>
       <Has name="path" value="/not"/>
       <Has name="properties" value="param0,param0Alternative2,param0Unbounded,param0Value"/>

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285-Expected-Input.xml
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285-Expected-Input.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<System name="Number">
+  <Has name="server" value="/"/>
+  <Has name="title" value="Number"/>
+  <Has name="version" value="0.0.0"/>
+  <Function name="POST_number">
+    <Has name="operation" value="POST"/>
+    <Has name="path" value="/number"/>
+    <Input type="query">
+      <VarSet name="param0">
+        <Has name="paramName" value="param0"/>
+        <Var name="Defined">
+          <Has name="style" value="form"/>
+          <Value name="Yes" property="param0"/>
+          <Value name="No"/>
+        </Var>
+        <Var name="Type" when="param0">
+          <Value name="number" property="param0Value"/>
+          <Value name="null" failure="true"/>
+          <Value name="Not number" failure="true"/>
+        </Var>
+        <VarSet name="Value" when="param0Value">
+          <Var name="Is">
+            <Value name="-3.15" failure="true"/>
+            <Value name="-3.14"/>
+            <Value name="3.14"/>
+            <Value name="3.15" failure="true"/>
+            <Value name="-3.139" failure="true"/>
+          </Var>
+        </VarSet>
+      </VarSet>
+      <VarSet name="param1">
+        <Has name="paramName" value="param1"/>
+        <Var name="Defined">
+          <Has name="style" value="form"/>
+          <Value name="Yes" property="param1"/>
+          <Value name="No"/>
+        </Var>
+        <Var name="Type" when="param1">
+          <Value name="number" property="param1Value"/>
+          <Value name="null" failure="true"/>
+          <Value name="Not number" failure="true"/>
+        </Var>
+        <VarSet name="Value" when="param1Value">
+          <Var name="Is">
+            <Value name="2.718"/>
+            <Value name="2.719" failure="true"/>
+            <Value name="&lt; 2.718" property="param1Unbounded"/>
+          </Var>
+          <VarSet name="Multiple-Of" when="param1Unbounded">
+            <Var name="0d001">
+              <Value name="Yes">
+                <Has name="multipleOf" value="0.001"/>
+              </Value>
+              <Value name="No" failure="true">
+                <Has name="multipleOf" value="0.001"/>
+              </Value>
+            </Var>
+          </VarSet>
+        </VarSet>
+      </VarSet>
+    </Input>
+  </Function>
+</System>

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285-Expected-Test.xml
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285-Expected-Test.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0"?>
+<TestCases system="Number">
+  <Has name="server" value="/"/>
+  <Has name="title" value="Number"/>
+  <Has name="version" value="0.0.0"/>
+  <Function name="POST_number">
+    <Has name="operation" value="POST"/>
+    <Has name="path" value="/number"/>
+    <Has name="server" value="/"/>
+    <Has name="title" value="Number"/>
+    <Has name="version" value="0.0.0"/>
+    <TestCase id="0" name="param0.Defined=&apos;Yes&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0,param0Value,param1,param1Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" value="-3.14">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="number">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" value="2.718">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="1" name="param0.Defined=&apos;No&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="No">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="2" name="param0.Value.Is=&apos;3.14&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0,param0Value,param1,param1Unbounded,param1Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" value="3.14">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="number">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" value="&lt; 2.718">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" value="Yes">
+          <Has name="multipleOf" value="0.001"/>
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="3" failure="true" name="param0.Type=null">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="null" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="4" failure="true" name="param0.Type=&apos;Not number&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="Not number" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="5" failure="true" name="param0.Value.Is=&apos;-3.15&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0,param0Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" value="-3.15" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="6" failure="true" name="param0.Value.Is=&apos;3.15&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0,param0Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" value="3.15" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="7" failure="true" name="param0.Value.Is=&apos;-3.139&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param0,param0Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="Yes">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" value="number">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" value="-3.139" failure="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="No">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="8" failure="true" name="param1.Type=null">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param1"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="No">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="null" failure="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="9" failure="true" name="param1.Type=&apos;Not number&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param1"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="No">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="Not number" failure="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="10" failure="true" name="param1.Value.Is=&apos;2.719&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param1,param1Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="No">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="number">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" value="2.719" failure="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" NA="true">
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+    <TestCase id="11" failure="true" name="param1.Value.Multiple-Of.0d001=&apos;No&apos;">
+      <Has name="operation" value="POST"/>
+      <Has name="path" value="/number"/>
+      <Has name="properties" value="param1,param1Unbounded,param1Value"/>
+      <Has name="server" value="/"/>
+      <Has name="title" value="Number"/>
+      <Has name="version" value="0.0.0"/>
+      <Input type="query">
+        <Var name="param0.Defined" value="No">
+          <Has name="paramName" value="param0"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param0.Type" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param0.Value.Is" NA="true">
+          <Has name="paramName" value="param0"/>
+        </Var>
+        <Var name="param1.Defined" value="Yes">
+          <Has name="paramName" value="param1"/>
+          <Has name="style" value="form"/>
+        </Var>
+        <Var name="param1.Type" value="number">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Is" value="&lt; 2.718">
+          <Has name="paramName" value="param1"/>
+        </Var>
+        <Var name="param1.Value.Multiple-Of.0d001" value="No" failure="true">
+          <Has name="multipleOf" value="0.001"/>
+          <Has name="paramName" value="param1"/>
+        </Var>
+      </Input>
+    </TestCase>
+  </Function>
+</TestCases>

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/number-285.json
@@ -1,0 +1,66 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Number",
+        "version": "0.0.0"
+    },
+    "paths": {
+        "/number": {
+            "post": {
+                "parameters": [
+                    {
+                        "name": "param0",
+                        "in": "query",
+                        "schema": {
+                            "type": "number",
+                            "maximum": 3.14,
+                            "minimum": -3.14,
+                            "multipleOf": 0.01
+                        }
+                    },
+                    {
+                        "name": "param1",
+                        "in": "query",
+                        "schema": {
+                            "type": "number",
+                            "maximum": 2.718,
+                            "multipleOf": 0.001
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/success"
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/failure"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "responses": {
+            "success": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            },
+            "failure": {
+                "description": "Error",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/not-4-Request-Cases.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/not-4-Request-Cases.json
@@ -382,6 +382,29 @@
     },
     {
         "id": 17,
+        "name": "param0.Alternative.1.Value.Is='0.01'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Not",
+        "path": "/not",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": 0.01
+                },
+                "valid": false
+            }
+        ],
+        "invalidInput": "param0.Alternative.1.Value.Is=0.01"
+    },
+    {
+        "id": 18,
         "name": "param0.Alternative.2.Value.Multiple-Of.7d5='Yes'",
         "server": "/",
         "version": "0.0.0",

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/number-285-Request-Cases.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/number-285-Request-Cases.json
@@ -1,0 +1,375 @@
+
+[
+    {
+        "id": 0,
+        "name": "param0.Defined='Yes'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": -3.14
+                },
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": 2.718
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "id": 1,
+        "name": "param0.Defined='No'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "name": "param0.Value.Is='3.14'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": 3.14
+                },
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": -4608304788595797994.916
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "id": 3,
+        "name": "param0.Type=null",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "null",
+                    "value": null
+                },
+                "valid": false
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ],
+        "invalidInput": "param0.Type=null"
+    },
+    {
+        "id": 4,
+        "name": "param0.Type='Not number'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "string",
+                    "value": "$yhhlf"
+                },
+                "valid": false
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ],
+        "invalidInput": "param0.Type=Not number"
+    },
+    {
+        "id": 5,
+        "name": "param0.Value.Is='-3.15'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": -3.15
+                },
+                "valid": false
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ],
+        "invalidInput": "param0.Value.Is=-3.15"
+    },
+    {
+        "id": 6,
+        "name": "param0.Value.Is='3.15'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": 3.15
+                },
+                "valid": false
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ],
+        "invalidInput": "param0.Value.Is=3.15"
+    },
+    {
+        "id": 7,
+        "name": "param0.Value.Is='-3.139'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": -3.139
+                },
+                "valid": false
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            }
+        ],
+        "invalidInput": "param0.Value.Is=-3.139"
+    },
+    {
+        "id": 8,
+        "name": "param1.Type=null",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "null",
+                    "value": null
+                },
+                "valid": false
+            }
+        ],
+        "invalidInput": "param1.Type=null"
+    },
+    {
+        "id": 9,
+        "name": "param1.Type='Not number'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "string",
+                    "value": "]%`4'D{w"
+                },
+                "valid": false
+            }
+        ],
+        "invalidInput": "param1.Type=Not number"
+    },
+    {
+        "id": 10,
+        "name": "param1.Value.Is='2.719'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": 2.719
+                },
+                "valid": false
+            }
+        ],
+        "invalidInput": "param1.Value.Is=2.719"
+    },
+    {
+        "id": 11,
+        "name": "param1.Value.Multiple-Of.0d001='No'",
+        "server": "/",
+        "version": "0.0.0",
+        "api": "Number",
+        "path": "/number",
+        "operation": "POST",
+        "parameters": [
+            {
+                "name": "param0",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": null,
+                "valid": true
+            },
+            {
+                "name": "param1",
+                "in": "query",
+                "style": "form",
+                "explode": false,
+                "data": {
+                    "type": "number",
+                    "value": -4611547743215701194.0529
+                },
+                "valid": false
+            }
+        ],
+        "invalidInput": "param1.Value.Multiple-Of.0d001=No"
+    }
+]

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-date-Request-Cases.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-date-Request-Cases.json
@@ -16,7 +16,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-01-04",
+                    "value": "2024-01-04",
                     "format": "date"
                 },
                 "valid": true
@@ -28,7 +28,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-26",
+                    "value": "2024-12-25",
                     "format": "date"
                 },
                 "valid": true
@@ -40,7 +40,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-01-09",
+                    "value": "2024-01-09",
                     "format": "date"
                 },
                 "valid": true
@@ -109,7 +109,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-24",
+                    "value": "2024-10-23",
                     "format": "date"
                 },
                 "valid": true
@@ -121,7 +121,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-05-21",
+                    "value": "2024-05-20",
                     "format": "date"
                 },
                 "valid": true
@@ -166,7 +166,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-11",
+                    "value": "2024-12-10",
                     "format": "date"
                 },
                 "valid": true
@@ -178,7 +178,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-20",
+                    "value": "2024-10-19",
                     "format": "date"
                 },
                 "valid": true
@@ -202,7 +202,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-05-0",
+                    "value": "2023-05-0",
                     "format": "date"
                 },
                 "valid": false
@@ -214,7 +214,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-04-05",
+                    "value": "2023-04-05",
                     "format": "date"
                 },
                 "valid": true
@@ -226,7 +226,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-07-17",
+                    "value": "2025-07-17",
                     "format": "date"
                 },
                 "valid": true
@@ -250,7 +250,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-04-260",
+                    "value": "2025-04-260",
                     "format": "date"
                 },
                 "valid": false
@@ -262,7 +262,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-03-26",
+                    "value": "2024-03-25",
                     "format": "date"
                 },
                 "valid": true
@@ -274,7 +274,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-08-02",
+                    "value": "2024-08-01",
                     "format": "date"
                 },
                 "valid": true
@@ -298,7 +298,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-03-04",
+                    "value": "2023-03-04",
                     "format": "date"
                 },
                 "valid": true
@@ -321,7 +321,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-24",
+                    "value": "2025-10-24",
                     "format": "date"
                 },
                 "valid": true
@@ -345,7 +345,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-09-19",
+                    "value": "2024-09-18",
                     "format": "date"
                 },
                 "valid": true
@@ -373,7 +373,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-06-22",
+                    "value": "2023-06-22",
                     "format": "date"
                 },
                 "valid": true
@@ -397,7 +397,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-06-28",
+                    "value": "2025-06-28",
                     "format": "date"
                 },
                 "valid": true
@@ -409,7 +409,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-04-1",
+                    "value": "2024-04-1",
                     "format": "date"
                 },
                 "valid": false
@@ -421,7 +421,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-08-27",
+                    "value": "2023-08-27",
                     "format": "date"
                 },
                 "valid": true
@@ -445,7 +445,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-01-29",
+                    "value": "2023-01-29",
                     "format": "date"
                 },
                 "valid": true
@@ -457,7 +457,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-01-200",
+                    "value": "2023-01-200",
                     "format": "date"
                 },
                 "valid": false
@@ -469,7 +469,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-08-11",
+                    "value": "2023-08-11",
                     "format": "date"
                 },
                 "valid": true
@@ -493,7 +493,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-06-09",
+                    "value": "2023-06-09",
                     "format": "date"
                 },
                 "valid": true
@@ -505,7 +505,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-04-06",
+                    "value": "2024-04-05",
                     "format": "date"
                 },
                 "valid": true
@@ -540,7 +540,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-04-04",
+                    "value": "2023-04-04",
                     "format": "date"
                 },
                 "valid": true
@@ -552,7 +552,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-08-23",
+                    "value": "2025-08-23",
                     "format": "date"
                 },
                 "valid": true
@@ -587,7 +587,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-04-06",
+                    "value": "2024-04-05",
                     "format": "date"
                 },
                 "valid": true
@@ -599,7 +599,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-06-08",
+                    "value": "2024-06-07",
                     "format": "date"
                 },
                 "valid": true
@@ -611,7 +611,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-2",
+                    "value": "2024-12-2",
                     "format": "date"
                 },
                 "valid": false
@@ -635,7 +635,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-12-27",
+                    "value": "2025-12-27",
                     "format": "date"
                 },
                 "valid": true
@@ -647,7 +647,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-02-09",
+                    "value": "2025-02-08",
                     "format": "date"
                 },
                 "valid": true
@@ -659,7 +659,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-11-300",
+                    "value": "2024-11-290",
                     "format": "date"
                 },
                 "valid": false

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-date-time-Request-Cases.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-date-time-Request-Cases.json
@@ -16,7 +16,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-11-17T21:03:21.329-06:00",
+                    "value": "2025-11-17T21:03:21.329-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -28,7 +28,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-06-16T18:25:12.551-05:00",
+                    "value": "2024-06-15T18:25:12.551-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -40,7 +40,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-04T15:42:20.453-05:00",
+                    "value": "2025-10-04T15:42:20.453-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -109,7 +109,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-01-04T03:31:58.151-06:00",
+                    "value": "2024-01-04T03:31:58.151-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -121,7 +121,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-25T03:32:24.280-05:00",
+                    "value": "2025-10-25T03:32:24.280-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -166,7 +166,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-07-03T12:55:22.137-05:00",
+                    "value": "2023-07-03T12:55:22.137-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -178,7 +178,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-01-02T07:18:46.326-06:00",
+                    "value": "2025-01-01T07:18:46.326-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -202,7 +202,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-11-26T08:55:52.591-06:0",
+                    "value": "2024-11-25T08:55:52.591-06:0",
                     "format": "date-time"
                 },
                 "valid": false
@@ -214,7 +214,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-09-16T06:08:41.091-05:00",
+                    "value": "2024-09-15T06:08:41.091-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -226,7 +226,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-03-21T02:06:13.330-05:00",
+                    "value": "2023-03-21T02:06:13.330-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -250,7 +250,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-01-14T13:45:29.439-06:000",
+                    "value": "2025-01-13T13:45:29.439-06:000",
                     "format": "date-time"
                 },
                 "valid": false
@@ -262,7 +262,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-15T23:20:01.765-05:00",
+                    "value": "2024-10-14T23:20:01.765-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -274,7 +274,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-12-02T14:17:39.578-06:00",
+                    "value": "2023-12-02T14:17:39.578-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -298,7 +298,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-08-06T10:27:34.889-05:00",
+                    "value": "2024-08-05T10:27:34.889-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -321,7 +321,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-03-06T23:35:26.038-06:00",
+                    "value": "2024-03-05T23:35:26.038-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -345,7 +345,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-09-03T19:10:22.974-05:00",
+                    "value": "2025-09-03T19:10:22.974-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -373,7 +373,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-04-05T16:39:18.479-05:00",
+                    "value": "2023-04-05T16:39:18.479-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -397,7 +397,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-12-02T16:56:53.429-06:00",
+                    "value": "2023-12-02T16:56:53.429-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -409,7 +409,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-21T15:52:47.202-06:0",
+                    "value": "2024-12-20T15:52:47.202-06:0",
                     "format": "date-time"
                 },
                 "valid": false
@@ -421,7 +421,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-01-20T09:09:37.152-06:00",
+                    "value": "2025-01-19T09:09:37.152-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -445,7 +445,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-25T10:43:19.500-06:00",
+                    "value": "2024-12-24T10:43:19.500-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -457,7 +457,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-29T12:53:31.827-05:000",
+                    "value": "2025-10-29T12:53:31.827-05:000",
                     "format": "date-time"
                 },
                 "valid": false
@@ -469,7 +469,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-02-13T20:12:47.280-06:00",
+                    "value": "2025-02-12T20:12:47.280-06:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -493,7 +493,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-08-17T04:58:16.694-05:00",
+                    "value": "2025-08-17T04:58:16.694-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -505,7 +505,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-07-25T07:21:54.722-05:00",
+                    "value": "2023-07-25T07:21:54.722-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -540,7 +540,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-04-29T04:31:56.133-05:00",
+                    "value": "2023-04-29T04:31:56.133-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -552,7 +552,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-08-18T04:04:47.881-05:00",
+                    "value": "2024-08-17T04:04:47.881-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -587,7 +587,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-06-17T07:47:12.428-05:00",
+                    "value": "2023-06-17T07:47:12.428-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -599,7 +599,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-04-03T01:27:00.822-05:00",
+                    "value": "2024-04-02T01:27:00.822-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -611,7 +611,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-08-29T16:30:08.173-05:0",
+                    "value": "2024-08-28T16:30:08.173-05:0",
                     "format": "date-time"
                 },
                 "valid": false
@@ -635,7 +635,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-08-26T20:37:35.725-05:00",
+                    "value": "2023-08-26T20:37:35.725-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -647,7 +647,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-07-19T10:52:10.132-05:00",
+                    "value": "2025-07-19T10:52:10.132-05:00",
                     "format": "date-time"
                 },
                 "valid": true
@@ -659,7 +659,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-03-30T03:05:02.493-05:000",
+                    "value": "2025-03-30T03:05:02.493-05:000",
                     "format": "date-time"
                 },
                 "valid": false

--- a/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-locations-Request-Cases.json
+++ b/tcases-openapi/src/test/resources/org/cornutum/tcases/openapi/resolver/string-locations-Request-Cases.json
@@ -105,7 +105,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-11-18",
+                    "value": "2024-11-17",
                     "format": "date"
                 },
                 "valid": true
@@ -217,7 +217,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-03-14",
+                    "value": "2023-03-14",
                     "format": "date"
                 },
                 "valid": true
@@ -326,7 +326,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-12-11",
+                    "value": "2025-12-11",
                     "format": "date"
                 },
                 "valid": true
@@ -438,7 +438,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-02-09",
+                    "value": "2023-02-09",
                     "format": "date"
                 },
                 "valid": true
@@ -544,7 +544,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-03-11",
+                    "value": "2024-03-10",
                     "format": "date"
                 },
                 "valid": true
@@ -654,7 +654,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-06-27",
+                    "value": "2023-06-27",
                     "format": "date"
                 },
                 "valid": true
@@ -764,7 +764,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-03-24",
+                    "value": "2024-03-23",
                     "format": "date"
                 },
                 "valid": true
@@ -874,7 +874,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-04-03",
+                    "value": "2023-04-03",
                     "format": "date"
                 },
                 "valid": true
@@ -981,7 +981,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-12-06",
+                    "value": "2024-12-05",
                     "format": "date"
                 },
                 "valid": true
@@ -1091,7 +1091,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-01-17",
+                    "value": "2023-01-17",
                     "format": "date"
                 },
                 "valid": true
@@ -1201,7 +1201,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-05-15",
+                    "value": "2025-05-15",
                     "format": "date"
                 },
                 "valid": true
@@ -1648,7 +1648,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-09-1",
+                    "value": "2025-09-1",
                     "format": "date"
                 },
                 "valid": false
@@ -1758,7 +1758,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-090",
+                    "value": "2024-10-080",
                     "format": "date"
                 },
                 "valid": false
@@ -1865,7 +1865,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-05-30",
+                    "value": "2023-05-30",
                     "format": "date"
                 },
                 "valid": true
@@ -1975,7 +1975,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-11-14",
+                    "value": "2023-11-14",
                     "format": "date"
                 },
                 "valid": true
@@ -2085,7 +2085,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-05-15",
+                    "value": "2023-05-15",
                     "format": "date"
                 },
                 "valid": true
@@ -2195,7 +2195,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-08-19",
+                    "value": "2025-08-19",
                     "format": "date"
                 },
                 "valid": true
@@ -2305,7 +2305,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-10-04",
+                    "value": "2023-10-04",
                     "format": "date"
                 },
                 "valid": true
@@ -2415,7 +2415,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-01-04",
+                    "value": "2025-01-03",
                     "format": "date"
                 },
                 "valid": true
@@ -2525,7 +2525,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-19",
+                    "value": "2024-10-18",
                     "format": "date"
                 },
                 "valid": true
@@ -2635,7 +2635,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-09",
+                    "value": "2024-10-08",
                     "format": "date"
                 },
                 "valid": true
@@ -2742,7 +2742,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-11-12",
+                    "value": "2024-11-11",
                     "format": "date"
                 },
                 "valid": true
@@ -2852,7 +2852,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-09-11",
+                    "value": "2025-09-11",
                     "format": "date"
                 },
                 "valid": true
@@ -2976,7 +2976,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-05-14",
+                    "value": "2025-05-14",
                     "format": "date"
                 },
                 "valid": true
@@ -3086,7 +3086,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-08-24",
+                    "value": "2023-08-24",
                     "format": "date"
                 },
                 "valid": true
@@ -3199,7 +3199,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-25",
+                    "value": "2025-10-25",
                     "format": "date"
                 },
                 "valid": true
@@ -3313,7 +3313,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-03-15",
+                    "value": "2023-03-15",
                     "format": "date"
                 },
                 "valid": true
@@ -3420,7 +3420,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-10-25",
+                    "value": "2025-10-25",
                     "format": "date"
                 },
                 "valid": true
@@ -3531,7 +3531,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-06-27",
+                    "value": "2023-06-27",
                     "format": "date"
                 },
                 "valid": true
@@ -3637,7 +3637,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-12-30",
+                    "value": "2023-12-30",
                     "format": "date"
                 },
                 "valid": true
@@ -3746,7 +3746,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-10-24",
+                    "value": "2023-10-24",
                     "format": "date"
                 },
                 "valid": true
@@ -3860,7 +3860,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-01-27",
+                    "value": "2025-01-26",
                     "format": "date"
                 },
                 "valid": true
@@ -3970,7 +3970,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-08",
+                    "value": "2024-10-07",
                     "format": "date"
                 },
                 "valid": true
@@ -4080,7 +4080,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-09-21",
+                    "value": "2023-09-21",
                     "format": "date"
                 },
                 "valid": true
@@ -4187,7 +4187,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-02-02",
+                    "value": "2024-02-02",
                     "format": "date"
                 },
                 "valid": true
@@ -4297,7 +4297,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-11-13",
+                    "value": "2023-11-13",
                     "format": "date"
                 },
                 "valid": true
@@ -4407,7 +4407,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-11-13",
+                    "value": "2025-11-13",
                     "format": "date"
                 },
                 "valid": true
@@ -4517,7 +4517,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2022-11-26",
+                    "value": "2023-11-26",
                     "format": "date"
                 },
                 "valid": true
@@ -4627,7 +4627,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2024-02-12",
+                    "value": "2025-02-11",
                     "format": "date"
                 },
                 "valid": true
@@ -4737,7 +4737,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-10-04",
+                    "value": "2024-10-03",
                     "format": "date"
                 },
                 "valid": true
@@ -4847,7 +4847,7 @@
                 "explode": false,
                 "data": {
                     "type": "string",
-                    "value": "2023-07-04",
+                    "value": "2024-07-03",
                     "format": "date"
                 },
                 "valid": true


### PR DESCRIPTION
This fixes issue #285 which occurred when `multipleOf` is a multiple of the unit for the value range.